### PR TITLE
Add [1] to select the first supported format

### DIFF
--- a/src/main/scripts/ctl/wcs.xml
+++ b/src/main/scripts/ctl/wcs.xml
@@ -6816,7 +6816,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">


### PR DESCRIPTION
Fix for #3 

I have added `[1]` to select only the first supported format. I think without the number of position the `xsl:value-of select` will concatenated all supported formats to one format.

Fix was not tested by me, because of no known WCS 1.1.1 service.
