### PR TITLE
Fixed #7: Error - cannot find declaration of element Capabilities

### DIFF
--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/example2dGridCRSdefault1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/example2dGridCRSdefault1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GridCRS xmlns="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:gml="http://www.opengis.net/gml" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGridCRS.xsd">
+	<GridBaseCRS>urn:ogc:def:crs:EPSG:6.6:4326</GridBaseCRS>
+	<GridOffsets>0.1 0.2</GridOffsets>
+</GridCRS>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/example2dGridCRSdefault2.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/example2dGridCRSdefault2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GridCRS xmlns="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:gml="http://www.opengis.net/gml" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGridCRS.xsd"
+	gml:id="example2dGridCrs1">
+	<gml:srsName>2D Grid CRS Example 1</gml:srsName>
+	<GridBaseCRS>urn:ogc:def:crs:EPSG:6.6:4326</GridBaseCRS>
+	<GridType>urn:ogc:def:method:WCS:1.1:2dGridIn2dCrs</GridType>
+	<GridOrigin>1.0 2.0</GridOrigin>
+	<GridOffsets>0.1 0 0 0.2</GridOffsets>
+	<GridCS>urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS</GridCS>
+</GridCRS>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/example2dGridCRSdefault3.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/example2dGridCRSdefault3.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GridCRS xmlns="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:gml="http://www.opengis.net/gml" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGridCRS.xsd"
+	gml:id="example2dGridCrs2">
+	<gml:srsName>2D Grid CRS Example 3</gml:srsName>
+	<GridBaseCRS>urn:ogc:def:crs:EPSG:6.6:4326</GridBaseCRS>
+	<GridType>urn:ogc:def:method:WCS:1.2:grid2dIn3dMethod</GridType>
+	<GridOrigin>0 0 0</GridOrigin>
+	<GridOffsets>0.0707 0.0707 0  -0.1414 0.1414 0</GridOffsets>
+	<GridCS>urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS</GridCS>
+</GridCRS>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCapabilities1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCapabilities1.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCapabilities.xsd http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsAll.xsd" 
+version="1.1.1" updateSequence="ABC123">
+	<!-- Partial example for WCS. Primary editor: Arliss Whiteside. Last updated 2007-06-12 -->
+	<ows:ServiceIdentification>
+		<ows:Title>Acme Corp. Coverage Server</ows:Title>
+		<ows:Abstract>Web Coverage Server maintained by Acme Corporation. </ows:Abstract>
+		<ows:Keywords>
+			<ows:Keyword>USA</ows:Keyword>
+		</ows:Keywords>
+		<ows:ServiceType>OGC WCS</ows:ServiceType>
+		<ows:ServiceTypeVersion>1.1.1</ows:ServiceTypeVersion>
+		<ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+		<ows:ServiceTypeVersion>0.8.3</ows:ServiceTypeVersion>
+		<ows:Fees>NONE</ows:Fees>
+		<ows:AccessConstraints>NONE</ows:AccessConstraints>
+	</ows:ServiceIdentification>
+	<ows:ServiceProvider>
+		<ows:ProviderName>Acme Corporation</ows:ProviderName>
+		<ows:ProviderSite xlink:href="http://hostname/"/>
+		<ows:ServiceContact>
+			<ows:IndividualName>Jeff Smith, Server Administrator</ows:IndividualName>
+			<ows:PositionName>Computer Scientist</ows:PositionName>
+			<ows:ContactInfo>
+				<ows:Phone>
+					<ows:Voice>+1 301 555-1212</ows:Voice>
+					<ows:Facsimile>+1 301 555-1212</ows:Facsimile>
+				</ows:Phone>
+				<ows:Address>
+					<ows:DeliveryPoint>NASA Goddard Space Flight Center</ows:DeliveryPoint>
+					<ows:City>Greenbelt</ows:City>
+					<ows:AdministrativeArea>MD</ows:AdministrativeArea>
+					<ows:PostalCode>20771</ows:PostalCode>
+					<ows:Country>USA</ows:Country>
+					<ows:ElectronicMailAddress>user@host.com</ows:ElectronicMailAddress>
+				</ows:Address>
+			</ows:ContactInfo>
+			<ows:Role>TBD</ows:Role>
+		</ows:ServiceContact>
+	</ows:ServiceProvider>
+	<ows:OperationsMetadata>
+		<ows:Operation name="GetCapabilities">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get xlink:href="http://hostname:port/path?"/>
+					<ows:Post xlink:href="http://hostname:port/path?"/>
+				</ows:HTTP>
+			</ows:DCP>
+		</ows:Operation>
+		<ows:Operation name="GetCoverage">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Post xlink:href="http://hostname:port/path?"/>
+				</ows:HTTP>
+			</ows:DCP>
+			<ows:Parameter name="Format">
+				<ows:AllowedValues>
+					<ows:Value>image/gif</ows:Value>
+					<ows:Value>image/png</ows:Value>
+					<ows:Value>image/jpeg</ows:Value>
+				</ows:AllowedValues>
+			</ows:Parameter>
+		</ows:Operation>
+		<ows:Operation name="DescribeCoverage">
+			<ows:DCP>
+				<ows:HTTP>
+					<ows:Get xlink:href="http://hostname:port/path?"/>
+				</ows:HTTP>
+			</ows:DCP>
+			<ows:Parameter name="Format">
+				<ows:AllowedValues>
+					<ows:Value>text/xml</ows:Value>
+				</ows:AllowedValues>
+			</ows:Parameter>
+		</ows:Operation>
+	</ows:OperationsMetadata>
+	<Contents>
+		<CoverageSummary>
+			<ows:Title>TBD</ows:Title>
+			<ows:Abstract>TBD</ows:Abstract>
+			<ows:WGS84BoundingBox>
+				<ows:LowerCorner>-9999 9999</ows:LowerCorner>
+				<ows:UpperCorner>9999 9999</ows:UpperCorner>
+			</ows:WGS84BoundingBox>
+			<Identifier>TBD</Identifier>
+		</CoverageSummary>
+	</Contents>
+</Capabilities>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCapabilities2.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCapabilities2.xml
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1  ../wcsGetCapabilities.xsd
+http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsAll.xsd" 
+version="1.1.1" updateSequence="1.0">
+   <!-- ************************************************************ -->
+   <!-- * SERVICE IDENTIFICATION SECTION                 * -->
+   <!-- ************************************************************ -->
+   <ows:ServiceIdentification>
+      <ows:Title>CubeWerx Demonstation WCS</ows:Title>
+      <ows:Abstract>A demonstration server used to illustrate CubeWerx's compilance with the Web Coverage Service 1.1.0 implementation specification</ows:Abstract>
+      <ows:Keywords>
+         <ows:Keyword>Web Coverage Service</ows:Keyword>
+         <ows:Keyword>06-083</ows:Keyword>
+         <ows:Keyword>CubeWerx</ows:Keyword>
+         <ows:Keyword>GeoTIFF</ows:Keyword>
+         <ows:Keyword>Imagery</ows:Keyword>
+      </ows:Keywords>
+      <ows:ServiceType>WCS</ows:ServiceType>
+      <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+      <ows:ServiceTypeVersion>1.1.1</ows:ServiceTypeVersion>
+      <ows:Fees>NONE</ows:Fees>
+      <ows:AccessConstraints>NONE</ows:AccessConstraints>
+   </ows:ServiceIdentification>
+   <!-- ************************************************************ -->
+   <!-- * SERVICE PROVIDER SECTION                         * -->
+   <!-- ************************************************************ -->
+   <ows:ServiceProvider>
+      <ows:ProviderName>CubeWerx Inc.</ows:ProviderName>
+      <ows:ProviderSite xlink:href="http://www.cubewerx.com"/>
+      <ows:ServiceContact>
+         <ows:IndividualName>Panagiotis (Peter) A. Vretanos</ows:IndividualName>
+         <ows:PositionName>Senior Developer</ows:PositionName>
+         <ows:ContactInfo>
+            <ows:Phone>
+               <ows:Voice>123-456-7890</ows:Voice>
+               <ows:Facsimile>234-567-8901</ows:Facsimile>
+            </ows:Phone>
+            <ows:Address>
+               <ows:DeliveryPoint>15 rue Gamelin</ows:DeliveryPoint>
+               <ows:DeliveryPoint>Suite 506</ows:DeliveryPoint>
+               <ows:City>Gatineau</ows:City>
+               <ows:AdministrativeArea>Quebec</ows:AdministrativeArea>
+               <ows:PostalCode>J8Y 6N5</ows:PostalCode>
+               <ows:Country>Canada</ows:Country>
+               <ows:ElectronicMailAddress>pvretano[at]cubewerx[dot]com</ows:ElectronicMailAddress>
+            </ows:Address>
+            <ows:OnlineResource xlink:href="http://www.cubewerx.com/~pvretano"/>
+            <ows:HoursOfService>24x7x365</ows:HoursOfService>
+            <ows:ContactInstructions>email</ows:ContactInstructions>
+         </ows:ContactInfo>
+         <ows:Role>Developer</ows:Role>
+      </ows:ServiceContact>
+   </ows:ServiceProvider>
+   <!-- ************************************************************ -->
+   <!-- * OPERATIONS METADATA                                * -->
+   <!-- ************************************************************ -->
+   <ows:OperationsMetadata>
+      <ows:Operation name="GetCapabilities">
+         <ows:DCP>
+            <ows:HTTP>
+               <ows:Get xlink:href="http://demo.cubewerx.com/demo/cubeserv/cubeserv.cgi?service=WMS&amp;"/>
+            </ows:HTTP>
+         </ows:DCP>
+         <ows:Parameter name="service">
+            <ows:AllowedValues>
+               <ows:Value>WCS</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="version">
+            <ows:AllowedValues>
+               <ows:Value>1.0.0</ows:Value>
+               <ows:Value>1.1.1</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="AcceptVersions">
+            <ows:AllowedValues>
+               <ows:Value>1.0.0</ows:Value>
+               <ows:Value>1.1.1</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+      </ows:Operation>
+      <ows:Operation name="DescribeCoverage">
+         <ows:DCP>
+            <ows:HTTP>
+               <ows:Get xlink:href="http://demo.cubewerx.com/demo/cubeserv/cubeserv.cgi?service=WMS&amp;"/>
+            </ows:HTTP>
+         </ows:DCP>
+         <ows:Parameter name="service">
+            <ows:AllowedValues>
+               <ows:Value>WCS</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="version">
+            <ows:AllowedValues>
+               <ows:Value>1.0.0</ows:Value>
+               <ows:Value>1.1.1</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="Identifier">
+            <ows:AllowedValues>
+               <ows:Value>ETOPO2</ows:Value>
+               <ows:Value>GTOPO30</ows:Value>
+               <ows:Value>RELIEF</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+      </ows:Operation>
+      <ows:Operation name="GetCoverage">
+         <ows:DCP>
+            <ows:HTTP>
+               <ows:Get xlink:href="http://demo.cubewerx.com/demo/cubeserv/cubeserv.cgi?service=WMS&amp;"/>
+            </ows:HTTP>
+         </ows:DCP>
+         <ows:Parameter name="service">
+            <ows:AllowedValues>
+               <ows:Value>WCS</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="version">
+            <ows:AllowedValues>
+               <ows:Value>1.0.0</ows:Value>
+               <ows:Value>1.1.1</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="Identifier">
+            <ows:AllowedValues>
+               <ows:Value>ETOPO2</ows:Value>
+               <ows:Value>GTOPO30</ows:Value>
+               <ows:Value>RELIEF</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="InterpolationType">
+            <ows:AllowedValues>
+               <ows:Value>nearestNeighbor</ows:Value>
+               <ows:Value>bilinear</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+         <ows:Parameter name="format">
+            <ows:AllowedValues>
+               <ows:Value>image/tiff</ows:Value>
+               <ows:Value>image/tiff; PhotometricInterpretation=RGB</ows:Value>
+               <ows:Value>image/png</ows:Value>
+               <ows:Value>image/png; PhotometricInterpretation=PaletteColor</ows:Value>
+               <ows:Value>image/png; PhotometricInterpretation=RGB</ows:Value>
+               <ows:Value>image/gif</ows:Value>
+               <ows:Value>image/jpeg</ows:Value>
+               <ows:Value>image/ppm</ows:Value>
+            </ows:AllowedValues>
+         </ows:Parameter>
+      </ows:Operation>
+   </ows:OperationsMetadata>
+   <!-- ************************************************************ -->
+   <!-- * CONTENTS SECTION                                        * -->
+   <!-- ************************************************************ -->
+   <Contents>
+      <CoverageSummary>
+         <ows:Title>Global 2 Minute Elevations</ows:Title>
+         <ows:Abstract>ETOPO2 was generated from a digital data base of land and sea-floor elevations on a 2-minute latitude/longitude grid. The data sources used to create the ETOPO2 data set were: Smith/Sandwell, GLOBE, DBDBV, IBCAO, and DBDB5</ows:Abstract>
+         <ows:Metadata xlink:href="http://www.ngdc.noaa.gov/mgg/image/2minrelief.html"/>
+         <ows:WGS84BoundingBox>
+            <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+            <ows:UpperCorner>+180.0 +90.0</ows:UpperCorner>
+         </ows:WGS84BoundingBox>
+         <Identifier>ETOPO2</Identifier>
+      </CoverageSummary>
+      <CoverageSummary>
+         <ows:Title>Global 30 Second Elevations</ows:Title>
+         <ows:Abstract>GTOPO30 is a global digital elevation model (DEM) resulting from a collaborative effort led by the staff at the U.S. Geological Survey's EROS Data Center in Sioux Falls, South Dakota.  Elevations in GTOPO30 are regularly spaced at 30-arc seconds (approximately 1 kilometer).  GTOPO30 was developed to meet the needs of the geospatial data user community for regional and continental scale topographic data.</ows:Abstract>
+         <ows:Metadata xlink:href="http://edcdaac.usgs.gov/gtopo30/README.html"/>
+         <ows:WGS84BoundingBox>
+            <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+            <ows:UpperCorner>+180.0 +90.0</ows:UpperCorner>
+         </ows:WGS84BoundingBox>
+         <Identifier>GTOPO30</Identifier>
+      </CoverageSummary>
+      <CoverageSummary>
+         <ows:Title>Two Minute Shaded Relief</ows:Title>
+         <ows:Abstract>This image was generated from digital data bases of seafloor and land elevations on a 2-minute latitude/longitude grid (1 minute of latitude = 1 nautical mile, or 1.852 km). Assumed illumination is from the west; shading is computed as a function of the east-west slope of the surface with a nonlinear exaggeration favoring low-relief areas. A Cylindrical Equidistant projection was used for the world image, which spans 360 degrees of of longitude from 180 West eastward to 180 East; latitude coverage is from 90 degrees North to 90 degrees South. The resolution of the gridded data varies from true 2-minute for the Atlantic, Pacific, andIndian Ocean floors and all land masses to 5 minutes for the Arctic Ocean floor. Clicking on a square above brings up a 512 x 512 pixel color relief image of the 45 degree area selected, clicking on the 512 x 512 image brings up the full-resolution 1350 x 1350 pixel (roughly 3 mb) color image of the area.</ows:Abstract>
+         <ows:Metadata xlink:href="http://www.ngdc.noaa.gov/mgg/image/2minrelief.html"/>
+         <ows:WGS84BoundingBox>
+            <ows:LowerCorner>-180.0 -90.0</ows:LowerCorner>
+            <ows:UpperCorner>+180.0 +90.0</ows:UpperCorner>
+         </ows:WGS84BoundingBox>
+         <Identifier>RELIEF</Identifier>
+      </CoverageSummary>
+      <SupportedCRS>urn:ogc:def:crs,AUTO:1.0:42001</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,AUTO:1.0:42002</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,AUTO:1.0:42003</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,AUTO:1.0:42004</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,CRS:1.0:27</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,CRS:1.0:83</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,CRS:1.0:84</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:100001</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:100002</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:102002</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:2163</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:2263</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:2283</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26703</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26704</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26705</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26706</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26707</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26708</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26709</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26710</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26711</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26712</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26713</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26714</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26715</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26716</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26717</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26718</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26719</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26720</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26721</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26722</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26903</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26904</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26905</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26906</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26907</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26908</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26909</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26910</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26911</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26912</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26913</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26914</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26915</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26916</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26917</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26918</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26919</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26920</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26921</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26922</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26923</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26930</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26985</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26986</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:26987</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:27582</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:27700</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:3005</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32118</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32128</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32129</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32601</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32602</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32603</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32604</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32605</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32606</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32607</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32608</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32609</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32610</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32611</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32612</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32613</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32614</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32615</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32616</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32617</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32618</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32619</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32620</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32621</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32622</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32623</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32624</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32625</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32626</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32627</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32628</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32629</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32630</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32631</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32632</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32633</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32634</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32635</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32636</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32637</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32638</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32639</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32640</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32641</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32642</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32643</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32644</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32645</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32646</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32647</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32648</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32649</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32650</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32651</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32652</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32653</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32654</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32655</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32656</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32657</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32658</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32659</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32660</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32701</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32702</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32703</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32704</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32705</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32706</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32707</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32708</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32709</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32710</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32711</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32712</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32713</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32714</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32715</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32716</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32717</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32718</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32719</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32720</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32721</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32722</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32723</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32724</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32725</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32726</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32727</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32728</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32729</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32730</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32731</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32732</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32733</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32734</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32735</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32736</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32737</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32738</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32739</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32740</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32741</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32742</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32743</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32744</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32745</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32746</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32747</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32748</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32749</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32750</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32751</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32752</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32753</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32754</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32755</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32756</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32757</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32758</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32759</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:32760</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:41001</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42101</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42103</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42104</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42105</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42106</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42301</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42302</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42303</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42304</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42305</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42306</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42307</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42308</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42309</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42310</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42311</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42312</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:42313</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:4267</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:4269</SupportedCRS>
+      <SupportedCRS>urn:ogc:def:crs,crs:EPSG:6.3:4326</SupportedCRS>
+      <SupportedFormat>image/tiff</SupportedFormat>
+      <SupportedFormat>image/tiff; PhotometricInterpretation=RGB</SupportedFormat>
+      <SupportedFormat>image/png</SupportedFormat>
+      <SupportedFormat>image/png; PhotometricInterpretation=PaletteColor</SupportedFormat>
+      <SupportedFormat>image/png; PhotometricInterpretation=RGB</SupportedFormat>
+      <SupportedFormat>image/gif</SupportedFormat>
+      <SupportedFormat>image/jpeg</SupportedFormat>
+      <SupportedFormat>image/ppm</SupportedFormat>
+   </Contents>
+</Capabilities>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCoverageDescription1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCoverageDescription1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CoverageDescriptions xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsDescribeCoverage.xsd 
+http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsAll.xsd">
+	<!-- Primary editor: Arliss Whiteside. Last updated 2007-06-05-->
+	<CoverageDescription>
+		<ows:Title>TBD</ows:Title>
+		<ows:Abstract>TBD</ows:Abstract>
+		<Identifier>TBD</Identifier>
+		<Domain>
+			<SpatialDomain>
+				<ows:BoundingBox>
+					<ows:LowerCorner>-30.00 -30.00</ows:LowerCorner>
+					<ows:UpperCorner>30.00 30.00</ows:UpperCorner>
+				</ows:BoundingBox>
+			</SpatialDomain>
+		</Domain>
+		<Range>
+			<Field>
+				<ows:Title>TBD</ows:Title>
+				<ows:Abstract>TBD</ows:Abstract>
+				<Identifier>TBD</Identifier>
+				<Definition>
+					<ows:AnyValue/>
+				</Definition>
+				<InterpolationMethods>
+					<InterpolationMethod>linear</InterpolationMethod>
+					<Default>cubic</Default>
+				</InterpolationMethods>
+			</Field>
+		</Range>
+		<SupportedCRS>urn:ogc:def:crs:EPSG::XXXX</SupportedCRS>
+		<SupportedCRS>urn:ogc:def:crs:EPSG::YYYY</SupportedCRS>
+		<SupportedFormat>text/xml</SupportedFormat>
+	</CoverageDescription>
+</CoverageDescriptions>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCoverageDescription2.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCoverageDescription2.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CoverageDescriptions xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:gml="http://www.opengis.net/gml"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsDescribeCoverage.xsd 
+http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsAll.xsd">	
+    <CoverageDescription>
+		<ows:Title>Coverage File: SPVIEW_530_274_0_020809_5_1_J_3.TIF</ows:Title>
+		<ows:Abstract>530_274_0_020809_5_1_J_3 Image, SAN FRANCISCO UNITED STATES, Cnes 1986-2002, Distribution Spot Image</ows:Abstract>
+		<ows:Keywords>
+			<ows:Keyword>SPOT5</ows:Keyword>
+			<ows:Keyword>HRG1</ows:Keyword>
+			<ows:Keyword>SPOT</ows:Keyword>
+		</ows:Keywords>
+		<Identifier>SPVIEW_530_274_0_020809_5_1_J_3</Identifier>
+		<Domain>
+			<SpatialDomain>
+				<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::26910">
+					<ows:LowerCorner>516430.13465702 4151612.8386696503</ows:LowerCorner>
+					<ows:UpperCorner>589060.13465702 4224332.83866965</ows:UpperCorner>
+				</ows:BoundingBox>
+                <GridCRS gml:id="SPVIEW_530_274_0_020809_5_1_J_3_CRS">
+					<gml:srsName>SPVIEW_530_274_0_020809_5_1_J_3_CRS</gml:srsName>
+					<GridBaseCRS>urn:ogc:def:crs:EPSG::26910</GridBaseCRS>
+					<GridType>urn:ogc:def:method:WCS:1.1:grid2dIn2dMethod</GridType>
+                	<GridOrigin>516430.13465702 4224332.83866965</GridOrigin>
+                	<GridOffsets>10.0 0 0 -10.0</GridOffsets>
+                	<GridCS>urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS</GridCS>
+                 </GridCRS>
+			</SpatialDomain>
+            <TemporalDomain>
+                <gml:timePosition>2002-08-09T19:08:46Z</gml:timePosition>
+            </TemporalDomain>			
+		</Domain>
+		<Range>
+			<Field>
+				<ows:Title>Wavelength</ows:Title>
+				<ows:Abstract>Wavelength Selection, 4 Channels</ows:Abstract>
+				<Identifier>Wavelength</Identifier>
+				<Definition>
+					<ows:AnyValue/>
+				</Definition>
+				<NullValue>0.0</NullValue>
+				<InterpolationMethods>
+					<InterpolationMethod>linear</InterpolationMethod>
+				    <Default>nearest</Default>
+				</InterpolationMethods>
+			    <Axis identifier="Band">
+					<AvailableKeys>
+				        <Key>band1</Key>
+				        <Key>band2</Key>
+				        <Key>band3</Key>
+				        <Key>band4</Key>
+					</AvailableKeys>
+				</Axis>				
+			</Field>
+		</Range>
+		<SupportedCRS>urn:ogc:def:crs:EPSG::4326</SupportedCRS>
+		<SupportedCRS>urn:ogc:def:crs:EPSG::26910</SupportedCRS>
+		<SupportedFormat>image/GeoTIFF</SupportedFormat>
+        <SupportedFormat>image/ECW</SupportedFormat>
+        <SupportedFormat>image/DTED</SupportedFormat>
+        <SupportedFormat>image/JPEG2000</SupportedFormat>
+		<SupportedFormat>image/NITF</SupportedFormat> 
+	</CoverageDescription>
+</CoverageDescriptions>
+

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCoverages1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleCoverages1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Coverages xmlns="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:ows="http://www.opengis.net/ows/1.1" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsAll.xsd http://www.opengis.net/ows/1.1 ../../../ows/1.1.0/owsAll.xsd">
+	<Coverage>
+		<ows:Title>TBD</ows:Title>
+		<ows:Abstract>Coverage created from GetCoverage operation request to a WCS</ows:Abstract>
+		<ows:Identifier>TBD</ows:Identifier>
+		<ows:Reference xlink:href="http://my.server.com/coverage/image.tiff" xlink:role="urn:ogc:def:role:WCS:1.1:coverage"/>
+		<ows:Reference xlink:href="http://my.server.com/coverage/metadata.xml" xlink:role="urn:ogc:def:role:WCS:1.1:metadata"/>
+	</Coverage>
+</Coverages>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleDescribeCoverage1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleDescribeCoverage1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeCoverage xmlns="http://www.opengis.net/wcs/1.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsDescribeCoverage.xsd" 
+service="WCS" version="1.1.1">
+	<Identifier>SPVIEW_530_274</Identifier>
+</DescribeCoverage>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleDescribeCoverage2.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleDescribeCoverage2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<DescribeCoverage xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsDescribeCoverage.xsd" 
+service="WCS" version="1.1.1">
+	<!-- Primary editor: Arliss Whiteside. Last updated 2007-06-05 -->
+	<Identifier>Landsat_TM_Mosaic</Identifier>
+	<Identifier>WMO_Daily_Temps</Identifier>
+	<Identifier>Census_population_tables</Identifier>
+</DescribeCoverage>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCapabilitiesMax.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCapabilitiesMax.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetCapabilities xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCapabilities.xsd" 
+service="WCS" updateSequence="XYZ123">
+	<!-- Maximum example for WCS. Primary editor: Arliss Whiteside. Last updated 2007-06-12-->
+	<ows:AcceptVersions>
+		<ows:Version>1.0.0</ows:Version>
+		<ows:Version>1.1.1</ows:Version>
+	</ows:AcceptVersions>
+	<ows:Sections>
+		<ows:Section>Contents</ows:Section>
+	</ows:Sections>
+	<ows:AcceptFormats>
+		<ows:OutputFormat>text/xml</ows:OutputFormat>
+	</ows:AcceptFormats>
+</GetCapabilities>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCapabilitiesMin.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCapabilitiesMin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetCapabilities xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCapabilities.xsd" 
+service="WCS"/>
+<!-- Minimum example for WCS. Primary editor: Arliss Whiteside. Last updated 2007-06-05-->

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage1.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCoverage.xsd" 
+service="WCS" version="1.1.1">
+	<ows:Identifier>Cov123</ows:Identifier>
+	<DomainSubset>
+		<ows:BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+			<ows:LowerCorner>-71 47</ows:LowerCorner>
+			<ows:UpperCorner>-66 51</ows:UpperCorner>
+		</ows:BoundingBox>
+	</DomainSubset>
+	<Output format="image/netcdf"/>
+</GetCoverage>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage2.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCoverage.xsd" 
+service="WCS" version="1.1.1">
+	<ows:Identifier>Cov123</ows:Identifier>
+	<DomainSubset>
+		<ows:BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+			<ows:LowerCorner>-71 47</ows:LowerCorner>
+			<ows:UpperCorner>-66 51</ows:UpperCorner>
+		</ows:BoundingBox>
+		<TemporalSubset>
+			<TimePeriod>
+				<BeginPosition>2006-08-01</BeginPosition>
+				<EndPosition>2006-09-01</EndPosition>
+				<TimeResolution>P1D</TimeResolution>
+			</TimePeriod>
+		</TemporalSubset>
+	</DomainSubset>
+	<Output format="image/netcdf">
+		<GridCRS>
+			<GridBaseCRS>urn:ogc:def:crs:EPSG:6.6:32618</GridBaseCRS>
+			<GridType>urn:ogc:def:method:WCS:1.1:2dGridin2dCrs</GridType>
+			<GridOrigin>3000 4000</GridOrigin>
+			<GridOffsets>6.0 8.0 -8.0 6.0</GridOffsets>
+			<GridCS>urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS</GridCS>
+		</GridCRS>
+	</Output>
+</GetCoverage>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage3.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage3.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCoverage.xsd" 
+service="WCS" version="1.1.1">
+	<!-- Partial example. Primary editor: Arliss Whiteside. Last updated 2007-06-05-->
+	<ows:Identifier>TBD</ows:Identifier>
+	<DomainSubset>
+		<ows:BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+			<ows:LowerCorner>9999 9999</ows:LowerCorner>
+			<ows:UpperCorner>9999 9999</ows:UpperCorner>
+		</ows:BoundingBox>
+	</DomainSubset>
+	<RangeSubset>
+		<FieldSubset>
+			<ows:Identifier>TBD</ows:Identifier>
+		</FieldSubset>
+	</RangeSubset>
+	<Output format="image/gif" store="false"/>
+</GetCoverage>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage4.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleGetCoverage4.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsGetCoverage.xsd http://www.opengis.net/gml ../../../gml/3.1.1/base/gml.xsd" 
+service="WCS" version="1.1.1">
+	<ows:Identifier>SPVIEW_530_274_0_020809_5_1_J_3</ows:Identifier>
+	<DomainSubset>
+		<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::26910">
+			<ows:LowerCorner>551182.3990 4173461.7219</ows:LowerCorner>
+			<ows:UpperCorner>569339.8990 4192512.2137</ows:UpperCorner>
+		</ows:BoundingBox>
+		<TemporalSubset>
+            <gml:timePosition>2002-08-09T19:08:46Z</gml:timePosition>
+		</TemporalSubset>
+	</DomainSubset>
+	<RangeSubset>
+		<FieldSubset>
+			<ows:Identifier>Wavelength</ows:Identifier>
+			<InterpolationType>nearest</InterpolationType>
+			<AxisSubset>
+			    <Identifier>Band</Identifier>
+		        <Key>band1</Key>
+		        <Key>band2</Key>
+		        <Key>band3</Key>
+			</AxisSubset>
+		</FieldSubset>
+	</RangeSubset>
+	<Output format="image/GeoTIFF" store="false">
+        <GridCRS gml:id="SPVIEW_530_274_0_020809_5_1_J_3_SUBSET_CRS">
+        	<gml:srsName>SPVIEW_530_274_0_020809_5_1_J_3_SUBSET_CRS</gml:srsName>
+        	<GridBaseCRS>urn:ogc:def:crs:EPSG::4326</GridBaseCRS>
+        	<GridType>urn:ogc:def:method:WCS:1.1:grid2dIn2dMethod</GridType>
+        	<GridOrigin>-122.4193 37.7058</GridOrigin>
+        	<GridOffsets>0.0006926667 0 0 -0.000548889</GridOffsets>
+        	<GridCS>urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS</GridCS>
+		</GridCRS>
+	</Output>
+</GetCoverage>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleInterpolationMethods1.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/Examples/exampleInterpolationMethods1.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<InterpolationMethods xmlns="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 ../wcsInterpolationMethod.xsd">
+	<InterpolationMethod>linear</InterpolationMethod>
+	<Default>nearest</Default>
+</InterpolationMethods>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/basicTypes.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/basicTypes.xsd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1">
+  <annotation>
+    <appinfo source="urn:opengis:specification:gml:schema-xsd:basicTypes:3.1.1"/>
+	<documentation>Subset of basicTypes.xsd for WCS 1.2 profile. Primary editor: Arliss Whiteside. Last updated 2007-04-23
+	Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+  </annotation>
+  <!-- =========================================================== -->
+  <!-- =========================================================== -->
+  <simpleType name="doubleList">
+    <annotation>
+      <documentation>XML List based on XML Schema double type.  An element of this type contains a space-separated list of double values</documentation>
+    </annotation>
+    <list itemType="double"/>
+  </simpleType>
+  <!-- =========================================================== -->
+  <simpleType name="integerList">
+    <annotation>
+      <documentation>XML List based on XML Schema integer type.  An element of this type contains a space-separated list of integer values</documentation>
+    </annotation>
+    <list itemType="integer"/>
+  </simpleType>
+  <!-- =========================================================== -->
+  <complexType name="CodeType">
+    <annotation>
+      <documentation>Name or code with an (optional) authority.  Text token.  
+      If the codeSpace attribute is present, then its value should identify a dictionary, thesaurus 
+      or authority for the term, such as the organisation who assigned the value, 
+      or the dictionary from which it is taken.  
+      A text string with an optional codeSpace attribute. </documentation>
+    </annotation>
+    <simpleContent>
+      <extension base="string">
+        <attribute name="codeSpace" type="anyURI" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <!-- =========================================================== -->
+  <complexType name="MeasureType">
+    <annotation>
+      <documentation>Number with a scale.  
+      The value of uom (Units Of Measure) attribute is a reference to a Reference System for the amount, either a ratio or position scale. </documentation>
+    </annotation>
+    <simpleContent>
+      <extension base="double">
+        <attribute name="uom" type="anyURI" use="required"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <!-- =========================================================== -->
+  <complexType name="MeasureListType">
+    <annotation>
+      <documentation>List of numbers with a uniform scale.  
+      The value of uom (Units Of Measure) attribute is a reference to 
+      a Reference System for the amount, either a ratio or position scale. </documentation>
+    </annotation>
+    <simpleContent>
+      <extension base="gml:doubleList">
+        <attribute name="uom" type="anyURI" use="required"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <!-- ============================================================ -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/coordinateOperations.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/coordinateOperations.xsd
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:coordinateOperations:3.1.1"/>
+		<documentation>Subset of coordinateOperations.xsd for WCS 1.2 profile. Primary editor: Arliss Whiteside. Last updated 2007-04-23 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ======================================================
+       includes and imports
+	====================================================== -->
+	<include schemaLocation="coordinateReferenceSystems.xsd"/>
+	<include schemaLocation="dataQuality.xsd"/>
+	<!-- ======================================================
+       elements and types
+	====================================================== -->
+	<element name="_CoordinateOperation" type="gml:AbstractCoordinateOperationType" abstract="true" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractCoordinateOperationBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for coordinate operation objects, simplifying and restricting the DefinitionType as needed. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:coordinateOperationName"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="coordinateOperationName" type="gml:CodeType" substitutionGroup="gml:name">
+		<annotation>
+			<documentation>The name by which this coordinate operation is identified. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="AbstractCoordinateOperationType" abstract="true">
+		<annotation>
+			<documentation>A mathematical operation on coordinates that transforms or converts coordinates to another coordinate reference system. Many but not all coordinate operations (from CRS A to CRS B) also uniquely define the inverse operation (from CRS B to CRS A). In some cases, the operation method algorithm for the inverse operation is the same as for the forward algorithm, but the signs of some operation parameter values must be reversed. In other cases, different algorithms are required for the forward and inverse operations, but the same operation parameter values are used. If (some) entirely different parameter values are needed, a different coordinate operation shall be defined.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractCoordinateOperationBaseType">
+				<sequence>
+					<element ref="gml:coordinateOperationID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alternative identifications of this coordinate operation. The first coordinateOperationID, if any, is normally the primary identification code, and any others are aliases. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on or information about this coordinate operation, including source information. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:operationVersion" minOccurs="0"/>
+					<element ref="gml:validArea" minOccurs="0"/>
+					<element ref="gml:scope" minOccurs="0"/>
+					<element ref="gml:_positionalAccuracy" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="gml:sourceCRS" minOccurs="0"/>
+					<element ref="gml:targetCRS" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="coordinateOperationID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of a coordinate operation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="operationVersion" type="string">
+		<annotation>
+			<documentation>Version of the coordinate transformation (i.e., instantiation due to the stochastic nature of the parameters). Mandatory when describing a transformation, and should not be supplied for a conversion. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="sourceCRS" type="gml:CRSRefType">
+		<annotation>
+			<documentation>Association to the source CRS (coordinate reference system) of this coordinate operation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="targetCRS" type="gml:CRSRefType">
+		<annotation>
+			<documentation>Association to the target CRS (coordinate reference system) of this coordinate operation. For constraints on multiplicity of "sourceCRS" and "targetCRS", see UML model of Coordinate Operation package in OGC Abstract Specification topic 2. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="CoordinateOperationRefType">
+		<annotation>
+			<documentation>Association to a coordinate operation, either referencing or containing the definition of that coordinate operation. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_CoordinateOperation"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="_SingleOperation" type="gml:AbstractCoordinateOperationType" abstract="true" substitutionGroup="gml:_CoordinateOperation">
+		<annotation>
+			<documentation>A single (not concatenated) coordinate operation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="_Operation" type="gml:AbstractCoordinateOperationType" abstract="true" substitutionGroup="gml:_SingleOperation">
+		<annotation>
+			<documentation>A parameterized mathematical operation on coordinates that transforms or converts coordinates to another coordinate reference system. This coordinate operation uses an operation method, usually with associated parameter values. However, operation methods and parameter values are directly associated with concrete subtypes, not with this abstract type.
+
+This abstract complexType shall not be directly used, extended, or restricted in a compliant Application Schema. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="ConcatenatedOperation" type="gml:ConcatenatedOperationType" substitutionGroup="gml:_CoordinateOperation"/>
+	<!-- =================================================== -->
+	<complexType name="ConcatenatedOperationType">
+		<annotation>
+			<documentation>An ordered sequence of two or more single coordinate operations. The sequence of operations is constrained by the requirement that the source coordinate reference system of step (n+1) must be the same as the target coordinate reference system of step (n). The source coordinate reference system of the first step and the target coordinate reference system of the last step are the source and target coordinate reference system associated with the concatenated operation. Instead of a forward operation, an inverse operation may be used for one or more of the operation steps mentioned above, if the inverse operation is uniquely defined by the forward operation.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractCoordinateOperationType">
+				<sequence>
+					<element ref="gml:usesSingleOperation" minOccurs="2" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Ordered sequence of associations to the two or more single operations used by this concatenated operation. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="usesSingleOperation" type="gml:SingleOperationRefType">
+		<annotation>
+			<documentation>Association to a single operation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="SingleOperationRefType">
+		<annotation>
+			<documentation>Association to a single operation, either referencing or containing the definition of that single operation. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_SingleOperation"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="PassThroughOperation" type="gml:PassThroughOperationType" substitutionGroup="gml:_SingleOperation"/>
+	<!-- =================================================== -->
+	<complexType name="PassThroughOperationType">
+		<annotation>
+			<documentation>A pass-through operation specifies that a subset of a coordinate tuple is subject to a specific coordinate operation. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractCoordinateOperationType">
+				<sequence>
+					<element ref="gml:modifiedCoordinate" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Ordered sequence of positive integers defining the positions in a coordinate tuple of the coordinates affected by this pass-through operation. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:usesOperation"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="modifiedCoordinate" type="positiveInteger">
+		<annotation>
+			<documentation>A positive integer defining a position in a coordinate tuple. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="usesOperation" type="gml:OperationRefType">
+		<annotation>
+			<documentation>Association to the operation applied to the specified ordinates. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="OperationRefType">
+		<annotation>
+			<documentation>Association to an abstract operation, either referencing or containing the definition of that operation. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_Operation"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+	<element name="_GeneralTransformation" type="gml:AbstractGeneralTransformationType" abstract="true" substitutionGroup="gml:_Operation"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractGeneralTransformationType" abstract="true">
+		<annotation>
+			<documentation>An abstract operation on coordinates that usually includes a change of Datum. The parameters of a coordinate transformation are empirically derived from data containing the coordinates of a series of points in both coordinate reference systems. This computational process is usually "over-determined", allowing derivation of error (or accuracy) estimates for the transformation. Also, the stochastic nature of the parameters may result in multiple (different) versions of the same coordinate transformation.
+
+This abstract complexType is expected to be extended for well-known operation methods with many Transformation instances, in Application Schemas that define operation-method-specialized value element names and contents. This transformation uses an operation method with associated parameter values. However, operation methods and parameter values are directly associated with concrete subtypes, not with this abstract type. All concrete types derived from this type shall extend this type to include a "usesMethod" element that references one "OperationMethod" element. Similarly, all concrete types derived from this type shall extend this type to include one or more elements each named "uses...Value" that each use the type of an element substitutable for the "_generalParameterValue" element. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:AbstractCoordinateOperationType">
+				<sequence>
+					<element ref="gml:coordinateOperationName"/>
+					<element ref="gml:coordinateOperationID" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="gml:remarks" minOccurs="0"/>
+					<element ref="gml:operationVersion"/>
+					<element ref="gml:validArea" minOccurs="0"/>
+					<element ref="gml:scope" minOccurs="0"/>
+					<element ref="gml:_positionalAccuracy" minOccurs="0" maxOccurs="unbounded"/>
+					<element ref="gml:sourceCRS"/>
+					<element ref="gml:targetCRS"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="Transformation" type="gml:TransformationType" substitutionGroup="gml:_GeneralTransformation"/>
+	<!-- =================================================== -->
+	<complexType name="TransformationType">
+		<annotation>
+			<documentation>A concrete operation on coordinates that usually includes a change of datum. The parameters of a coordinate transformation are empirically derived from data containing the coordinates of a series of points in both coordinate reference systems. This computational process is usually "over-determined", allowing derivation of error (or accuracy) estimates for the transformation. Also, the stochastic nature of the parameters may result in multiple (different) versions of the same coordinate transformation.
+
+This concrete complexType can be used for all operation methods, without using an Application Schema that defines operation-method-specialized element names and contents, especially for methods with only one Transformation instance. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractGeneralTransformationType">
+				<sequence>
+					<element ref="gml:usesMethod"/>
+					<element ref="gml:usesValue" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered set of composition associations to the set of parameter values used by this transformation operation. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="usesMethod" type="gml:OperationMethodRefType">
+		<annotation>
+			<documentation>Association to the operation method used by this coordinate operation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="usesValue" type="gml:ParameterValueType">
+		<annotation>
+			<documentation>Composition association to a parameter value used by this coordinate operation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+	<element name="_generalParameterValue" type="gml:AbstractGeneralParameterValueType" abstract="true"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractGeneralParameterValueType" abstract="true">
+		<annotation>
+			<documentation>Abstract parameter value or group of parameter values.
+			
+This abstract complexType is expected to be extended and restricted for well-known operation methods with many instances, in Application Schemas that define operation-method-specialized element names and contents. Specific parameter value elements are directly contained in concrete subtypes, not in this abstract type. All concrete types derived from this type shall extend this type to include one "...Value" element with an appropriate type, which should be one of the element types allowed in the ParameterValueType. In addition, all derived concrete types shall extend this type to include a "valueOfParameter" element that references one element substitutable for the "OperationParameter" element. </documentation>
+		</annotation>
+		<sequence/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="parameterValue" type="gml:ParameterValueType" substitutionGroup="gml:_generalParameterValue"/>
+	<!-- =================================================== -->
+	<complexType name="ParameterValueType">
+		<annotation>
+			<documentation>A parameter value, ordered sequence of values, or reference to a file of parameter values. This concrete complexType can be used for operation methods without using an Application Schema that defines operation-method-specialized element names and contents, especially for methods with only one instance. This complexType can be used, extended, or restricted for well-known operation methods, especially for methods with many instances. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractGeneralParameterValueType">
+				<sequence>
+					<choice>
+						<element ref="gml:value"/>
+						<element ref="gml:stringValue"/>
+						<element ref="gml:integerValue"/>
+						<element ref="gml:booleanValue"/>
+						<element ref="gml:valueList"/>
+						<element ref="gml:integerValueList"/>
+						<element ref="gml:valueFile"/>
+					</choice>
+					<element ref="gml:valueOfParameter"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="value" type="gml:MeasureType">
+		<annotation>
+			<documentation>Numeric value of an operation parameter, with its associated unit of measure. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="stringValue" type="string">
+		<annotation>
+			<documentation>String value of an operation parameter. A string value does not have an associated unit of measure. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="integerValue" type="positiveInteger">
+		<annotation>
+			<documentation>Positive integer value of an operation parameter, usually used for a count. An integer value does not have an associated unit of measure. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="booleanValue" type="boolean">
+		<annotation>
+			<documentation>Boolean value of an operation parameter. A Boolean value does not have an associated unit of measure. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="valueList" type="gml:MeasureListType">
+		<annotation>
+			<documentation>Ordered sequence of two or more numeric values of an operation parameter list, where each value has the same associated unit of measure. An element of this type contains a space-separated sequence of double values. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="integerValueList" type="gml:integerList">
+		<annotation>
+			<documentation>Ordered sequence of two or more integer values of an operation parameter list, usually used for counts. These integer values do not have an associated unit of measure. An element of this type contains a space-separated sequence of integer values. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="valueFile" type="anyURI">
+		<annotation>
+			<documentation>Reference to a file or a part of a file containing one or more parameter values, each numeric value with its associated unit of measure. When referencing a part of a file, that file must contain multiple identified parts, such as an XML encoded document. Furthermore, the referenced file or part of a file can reference another part of the same or different files, as allowed in XML documents. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="valueOfParameter" type="gml:OperationParameterRefType">
+		<annotation>
+			<documentation>Association to the operation parameter that this is a value of. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+	<element name="OperationMethod" type="gml:OperationMethodType" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="OperationMethodBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for operation method objects, simplifying and restricting the DefinitionType as needed. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:methodName"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="methodName" type="gml:CodeType" substitutionGroup="gml:name">
+		<annotation>
+			<documentation>The name by which this operation method is identified. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="OperationMethodType">
+		<annotation>
+			<documentation>Definition of an algorithm used to perform a coordinate operation. Most operation methods use a number of operation parameters, although some coordinate conversions use none. Each coordinate operation using the method assigns values to these parameters. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:OperationMethodBaseType">
+				<sequence>
+					<element ref="gml:methodID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alternative identifications of this operation method. The first methodID, if any, is normally the primary identification code, and any others are aliases. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on or information about this operation method, including source information.</documentation>
+						</annotation>
+					</element>
+					<element ref="gml:methodFormula"/>
+					<element ref="gml:sourceDimensions"/>
+					<element ref="gml:targetDimensions"/>
+					<element ref="gml:usesParameter" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of associations to the set of operation parameters and parameter groups used by this operation method. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="methodID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of an operation method. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="methodFormula" type="gml:CodeType">
+		<annotation>
+			<documentation>Formula(s) used by this operation method. The value may be a reference to a publication. Note that the operation method may not be analytic, in which case this element references or contains the procedure, not an analytic formula.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="sourceDimensions" type="positiveInteger">
+		<annotation>
+			<documentation>Number of dimensions in the source CRS of this operation method. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="targetDimensions" type="positiveInteger">
+		<annotation>
+			<documentation>Number of dimensions in the target CRS of this operation method. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="usesParameter" type="gml:AbstractGeneralOperationParameterRefType">
+		<annotation>
+			<documentation>Association to an operation parameter or parameter group used by this operation method. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="OperationMethodRefType">
+		<annotation>
+			<documentation>Association to a concrete general-purpose operation method, either referencing or containing the definition of that method. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:OperationMethod"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+	<element name="_GeneralOperationParameter" type="gml:AbstractGeneralOperationParameterType" abstract="true" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractGeneralOperationParameterType" abstract="true">
+		<annotation>
+			<documentation>Abstract definition of a parameter or group of parameters used by an operation method. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:minimumOccurs" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="minimumOccurs" type="nonNegativeInteger">
+		<annotation>
+			<documentation>The minimum number of times that values for this parameter group or parameter are required. If this attribute is omitted, the minimum number is one. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="AbstractGeneralOperationParameterRefType">
+		<annotation>
+			<documentation>Association to an operation parameter or group, either referencing or containing the definition of that parameter or group. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_GeneralOperationParameter"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="OperationParameter" type="gml:OperationParameterType" substitutionGroup="gml:_GeneralOperationParameter"/>
+	<!-- =================================================== -->
+	<complexType name="OperationParameterBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for operation parameter objects, simplifying and restricting the DefinitionType as needed. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:AbstractGeneralOperationParameterType">
+				<sequence>
+					<element ref="gml:parameterName"/>
+					<element ref="gml:minimumOccurs" minOccurs="0"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="parameterName" type="gml:CodeType" substitutionGroup="gml:name">
+		<annotation>
+			<documentation>The name by which this operation parameter is identified. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="OperationParameterType">
+		<annotation>
+			<documentation>The definition of a parameter used by an operation method. Most parameter values are numeric, but other types of parameter values are possible. This complexType is expected to be used or extended for all operation methods, without defining operation-method-specialized element names.  </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:OperationParameterBaseType">
+				<sequence>
+					<element ref="gml:parameterID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alternative identifications of this operation parameter. The first parameterID, if any, is normally the primary identification code, and any others are aliases. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on or information about this operation parameter, including source information. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="parameterID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of an operation parameter. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="OperationParameterRefType">
+		<annotation>
+			<documentation>Association to an operation parameter, either referencing or containing the definition of that parameter. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:OperationParameter"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/coordinateReferenceSystems.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/coordinateReferenceSystems.xsd
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:coordinateReferenceSystems:3.1.1"/>
+		<documentation>Subset of coordinateReferenceOperations.xsd for WCS 1.2 profile. Primary editor: Arliss Whiteside. Last updated 2007-04-23 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ======================================================
+       includes and imports
+	====================================================== -->
+	<include schemaLocation="datums.xsd"/>
+	<include schemaLocation="coordinateSystems.xsd"/>
+	<!-- ======================================================
+       elements and types
+	====================================================== -->
+	<element name="_CoordinateReferenceSystem" type="gml:AbstractReferenceSystemType" abstract="true" substitutionGroup="gml:_CRS">
+		<annotation>
+			<documentation>A coordinate reference system consists of an ordered sequence of coordinate system axes that are related to the earth through a datum. A coordinate reference system is defined by one datum and by one coordinate system. Most coordinate reference system do not move relative to the earth, except for engineering coordinate reference systems defined on moving platforms such as cars, ships, aircraft, and spacecraft. For further information, see OGC Abstract Specification Topic 2.
+
+Coordinate reference systems are commonly divided into sub-types. The common classification criterion for sub-typing of coordinate reference systems is the way in which they deal with earth curvature. This has a direct effect on the portion of the earth's surface that can be covered by that type of CRS with an acceptable degree of error. The exception to the rule is the subtype "Temporal" which has been added by analogy. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="ImageCRS" type="gml:ImageCRSType" substitutionGroup="gml:_CoordinateReferenceSystem"/>
+	<!-- =================================================== -->
+	<complexType name="ImageCRSType">
+		<annotation>
+			<documentation>An engineering coordinate reference system applied to locations in images. Image coordinate reference systems are treated as a separate sub-type because a separate user community exists for images with its own terms of reference. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractReferenceSystemType">
+				<sequence>
+					<choice>
+						<element ref="gml:usesCartesianCS"/>
+					</choice>
+					<element ref="gml:usesImageDatum"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="usesCartesianCS" type="gml:CartesianCSRefType">
+		<annotation>
+			<documentation>Association to the Cartesian coordinate system used by this CRS. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="usesImageDatum" type="gml:ImageDatumRefType">
+		<annotation>
+			<documentation>Association to the image datum used by this CRS. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/coordinateSystems.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/coordinateSystems.xsd
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:coordinateSystems:3.1.1"/>
+		<documentation>Subset of coordinateSystems.xsd for WCS 1.2 profile. 
+		Primary editor: Arliss Whiteside. Last updated 2008-02-14. 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ======================================================
+       includes and imports
+	====================================================== -->
+	<include schemaLocation="referenceSystems.xsd"/>
+	<!-- ======================================================
+       elements and types
+	====================================================== -->
+	<element name="CoordinateSystemAxis" type="gml:CoordinateSystemAxisType" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="CoordinateSystemAxisBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for coordinate system axis objects, simplifying and restricting the DefinitionType as needed. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:description" minOccurs="0">
+						<annotation>
+							<documentation>This optional element shall not be included when using this gml4wcs profile of GML 3.1.1. For some unknown reason, this schema document does not validate if this element is omitted here as desired. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:name">
+						<annotation>
+							<documentation>The name by which this coordinate system axis is identified. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<complexType name="CoordinateSystemAxisType">
+		<annotation>
+			<documentation>Definition of a coordinate system axis. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:CoordinateSystemAxisBaseType">
+				<sequence>
+					<element ref="gml:axisID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alternative identifications of this coordinate system axis. The first axisID, if any, is normally the primary identification code, and any others are aliases. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on or information about this coordinate system axis, including data source information. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:axisAbbrev"/>
+					<element ref="gml:axisDirection"/>
+				</sequence>
+				<attribute ref="gml:uom" use="required"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="axisID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of a coordinate system axis. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="axisAbbrev" type="gml:CodeType">
+		<annotation>
+			<documentation>The abbreviation used for this coordinate system axis. This abbreviation can be used to identify the ordinates in a coordinate tuple. Examples are X and Y. The codeSpace attribute can reference a source of more information on a set of standardized abbreviations, or on this abbreviation. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="axisDirection" type="gml:CodeType">
+		<annotation>
+			<documentation>Direction of this coordinate system axis (or in the case of Cartesian projected coordinates, the direction of this coordinate system axis at the origin). Examples: north or south, east or west, up or down. Within any set of coordinate system axes, only one of each pair of terms can be used. For earth-fixed CRSs, this direction is often approximate and intended to provide a human interpretable meaning to the axis. When a geodetic datum is used, the precise directions of the axes may therefore vary slightly from this approximate direction. Note that an EngineeringCRS can include specific descriptions of the directions of its coordinate system axes. For example, the path of a linear CRS axis can be referenced in another document, such as referencing a GML feature that references or includes a curve geometry. The codeSpace attribute can reference a source of more information on a set of standardized directions, or on this direction. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<attribute name="uom" type="anyURI">
+		<annotation>
+			<documentation>Identifier of the unit of measure used for this coordinate system axis. The value of this coordinate in a coordinate tuple shall be recorded using this unit of measure, whenever those coordinates use a coordinate reference system that uses a coordinate system that uses this axis.</documentation>
+		</annotation>
+	</attribute>
+	<!-- =================================================== -->
+	<complexType name="CoordinateSystemAxisRefType">
+		<annotation>
+			<documentation>Association to a coordinate system axis, either referencing or containing the definition of that axis. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:CoordinateSystemAxis"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+	<element name="_CoordinateSystem" type="gml:AbstractCoordinateSystemType" abstract="true" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractCoordinateSystemBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for coordinate system objects, simplifying and restricting the DefinitionType as needed. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:csName"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="csName" type="gml:CodeType" substitutionGroup="gml:name">
+		<annotation>
+			<documentation>The name by which this coordinate system is identified. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="AbstractCoordinateSystemType" abstract="true">
+		<annotation>
+			<documentation>A coordinate system (CS) is the set of coordinate system axes that spans a given coordinate space. A CS is derived from a set of (mathematical) rules for specifying how coordinates in a given space are to be assigned to points. The coordinate values in a coordinate tuple shall be recorded in the order in which the coordinate system axes associations are recorded, whenever those coordinates use a coordinate reference system that uses this coordinate system. This abstract complexType shall not be used, extended, or restricted, in an Application Schema, to define a concrete subtype with a meaning equivalent to a concrete subtype specified in this document. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractCoordinateSystemBaseType">
+				<sequence>
+					<element ref="gml:csID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alternative identifications of this coordinate system. The first csID, if any, is normally the primary identification code, and any others are aliases. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on or information about this coordinate system, including data source information. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:usesAxis" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Ordered sequence of associations to the coordinate system axes included in this coordinate system. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="csID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of a coordinate system. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="usesAxis" type="gml:CoordinateSystemAxisRefType">
+		<annotation>
+			<documentation>Association to a coordinate system axis. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="CoordinateSystemRefType">
+		<annotation>
+			<documentation>Association to a coordinate system, either referencing or containing the definition of that coordinate system. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_CoordinateSystem"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="CartesianCS" type="gml:CartesianCSType" substitutionGroup="gml:_CoordinateSystem"/>
+	<!-- =================================================== -->
+	<complexType name="CartesianCSType">
+		<annotation>
+			<documentation>A 1-, 2-, or 3-dimensional coordinate system. Gives the position of points relative to orthogonal straight axes in the 2- and 3-dimensional cases. In the 1-dimensional case, it contains a single straight coordinate axis. In the multi-dimensional case, all axes shall have the same length unit of measure. A CartesianCS shall have one, two, or three usesAxis associations. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractCoordinateSystemType"/>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<complexType name="CartesianCSRefType">
+		<annotation>
+			<documentation>Association to a Cartesian coordinate system, either referencing or containing the definition of that coordinate system. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:CartesianCS"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/dataQuality.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/dataQuality.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:dataQuality:3.1.1"/>
+		<documentation>Subset of dataQuality.xsd for WCS 1.2 profile. Primary editor: Arliss Whiteside. Last updated 2007-04-23
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ======================================================
+       includes and imports
+	====================================================== -->
+	<include schemaLocation="units.xsd"/>
+	<!-- ======================================================
+       elements and types
+	====================================================== -->
+	<element name="_positionalAccuracy" type="gml:AbstractPositionalAccuracyType" abstract="true"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractPositionalAccuracyType" abstract="true">
+		<annotation>
+			<documentation>Position error estimate (or accuracy) data. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:measureDescription" minOccurs="0"/>
+		</sequence>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="measureDescription" type="gml:CodeType">
+		<annotation>
+			<documentation>A description of the position accuracy parameter(s) provided. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="absoluteExternalPositionalAccuracy" type="gml:AbsoluteExternalPositionalAccuracyType" substitutionGroup="gml:_positionalAccuracy"/>
+	<!-- =================================================== -->
+	<complexType name="AbsoluteExternalPositionalAccuracyType">
+		<annotation>
+			<documentation>Closeness of reported coordinate values to values accepted as or being true. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractPositionalAccuracyType">
+				<sequence>
+					<element ref="gml:result"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="relativeInternalPositionalAccuracy" type="gml:RelativeInternalPositionalAccuracyType" substitutionGroup="gml:_positionalAccuracy"/>
+	<!-- =================================================== -->
+	<complexType name="RelativeInternalPositionalAccuracyType">
+		<annotation>
+			<documentation>Closeness of the relative positions of two or more positions to their respective relative positions accepted as or being true. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractPositionalAccuracyType">
+				<sequence>
+					<element ref="gml:result"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="result" type="gml:MeasureType">
+		<annotation>
+			<documentation>A quantitative result defined by the evaluation procedure used, and identified by the measureDescription. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="covarianceMatrix" type="gml:CovarianceMatrixType" substitutionGroup="gml:_positionalAccuracy"/>
+	<!-- =================================================== -->
+	<complexType name="CovarianceMatrixType">
+		<annotation>
+			<documentation>Error estimate covariance matrix. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractPositionalAccuracyType">
+				<sequence>
+					<element ref="gml:unitOfMeasure" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Ordered sequence of units of measure, corresponding to the row and column index numbers of the covariance matrix, starting with row and column 1 and ending with row/column N. Each unit of measure is for the ordinate reflected in the relevant row and column of the covariance matrix. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:includesElement" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered set of elements in this covariance matrix. Because the covariance matrix is symmetrical, only the elements in the upper or lower diagonal part (including the main diagonal) of the matrix need to be specified. Any zero valued covariance elements can be omitted. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="includesElement" type="gml:CovarianceElementType"/>
+	<!-- =================================================== -->
+	<complexType name="CovarianceElementType">
+		<annotation>
+			<documentation>An element of a covariance matrix.</documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:rowIndex"/>
+			<element ref="gml:columnIndex"/>
+			<element ref="gml:covariance"/>
+		</sequence>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="rowIndex" type="positiveInteger">
+		<annotation>
+			<documentation>Row number of this covariance element value. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="columnIndex" type="positiveInteger">
+		<annotation>
+			<documentation>Column number of this covariance element value. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="covariance" type="double">
+		<annotation>
+			<documentation>Value of covariance matrix element. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/datums.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/datums.xsd
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:datums:3.1.1"/>
+		<documentation>Subset of datums.xsd for WCS 1.2 profile. Primary editor: Arliss Whiteside. Last updated 2007-04-23 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ======================================================
+       includes and imports
+	====================================================== -->
+	<include schemaLocation="referenceSystems.xsd"/>
+	<!-- ======================================================
+       elements and types
+	====================================================== -->
+	<element name="_Datum" type="gml:AbstractDatumType" abstract="true" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractDatumBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for datum objects, simplifying and restricting the DefinitionType as needed. </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:datumName"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="datumName" type="gml:CodeType" substitutionGroup="gml:name">
+		<annotation>
+			<documentation>The name by which this datum is identified. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="AbstractDatumType" abstract="true">
+		<annotation>
+			<documentation>A datum specifies the relationship of a coordinate system to the earth, thus creating a coordinate reference system. A datum uses a parameter or set of parameters that determine the location of the origin of the coordinate reference system. Each datum subtype can be associated with only specific types of coordinate systems. This abstract complexType shall not be used, extended, or restricted, in an Application Schema, to define a concrete subtype with a meaning equivalent to a concrete subtype specified in this document. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractDatumBaseType">
+				<sequence>
+					<element ref="gml:datumID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alternative identifications of this datum. The first datumID, if any, is normally the primary identification code, and any others are aliases. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on this reference system, including source information. </documentation>
+						</annotation>
+					</element>
+					<element ref="gml:anchorPoint" minOccurs="0"/>
+					<element ref="gml:realizationEpoch" minOccurs="0"/>
+					<element ref="gml:validArea" minOccurs="0"/>
+					<element ref="gml:scope" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="datumID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of a datum. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="anchorPoint" type="gml:CodeType">
+		<annotation>
+			<documentation>Description, possibly including coordinates, of the point or points used to anchor the datum to the Earth. Also known as the "origin", especially for engineering and image datums. The codeSpace attribute can be used to reference a source of more detailed on this point or surface, or on a set of such descriptions. 
+- For a geodetic datum, this point is also known as the fundamental point, which is traditionally the point where the relationship between geoid and ellipsoid is defined. In some cases, the "fundamental point" may consist of a number of points. In those cases, the parameters defining the geoid/ellipsoid relationship have been averaged for these points, and the averages adopted as the datum definition.
+- For an engineering datum, the anchor point may be a physical point, or it may be a point with defined coordinates in another CRS. When appropriate, the coordinates of this anchor point can be referenced in another document, such as referencing a GML feature that references or includes a point position.
+- For an image datum, the anchor point is usually either the centre of the image or the corner of the image.
+- For a temporal datum, this attribute is not defined. Instead of the anchor point, a temporal datum carries a separate time origin of type DateTime. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="realizationEpoch" type="date">
+		<annotation>
+			<documentation>The time after which this datum definition is valid. This time may be precise (e.g. 1997.0 for IRTF97) or merely a year (e.g. 1983 for NAD83). In the latter case, the epoch usually refers to the year in which a major recalculation of the geodetic control network, underlying the datum, was executed or initiated. An old datum can remain valid after a new datum is defined. Alternatively, a datum may be superseded by a later datum, in which case the realization epoch for the new datum defines the upper limit for the validity of the superseded datum. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="ImageDatum" type="gml:ImageDatumType" substitutionGroup="gml:_Datum"/>
+	<!-- =================================================== -->
+	<complexType name="ImageDatumType">
+		<annotation>
+			<documentation>An image datum defines the origin of an image coordinate reference system, and is used in a local context only. For more information, see OGC Abstract Specification Topic 2. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractDatumType">
+				<sequence>
+					<element ref="gml:pixelInCell"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="pixelInCell" type="gml:PixelInCellType"/>
+	<!-- =================================================== -->
+	<complexType name="PixelInCellType">
+		<annotation>
+			<documentation>Specification of the way an image grid is associated with the image data attributes. </documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:CodeType">
+				<attribute name="codeSpace" type="anyURI" use="required">
+					<annotation>
+						<documentation>Reference to a source of information specifying the values and meanings of all the allowed string values for this PixelInCellType. </documentation>
+					</annotation>
+				</attribute>
+			</restriction>
+		</simpleContent>
+	</complexType>
+	<!-- =================================================== -->
+	<complexType name="ImageDatumRefType">
+		<annotation>
+			<documentation>Association to an image datum, either referencing or containing the definition of that datum. </documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:ImageDatum"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/dictionary.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/dictionary.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml"
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" >
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd::3.1.1"/>
+		<documentation>Subset of dictionary.xsd for WCS 1.2 profile. Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-04-23
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ========================================================
+       includes and imports
+	======================================================== -->
+	<include schemaLocation="gmlBase.xsd"/>
+	<!-- ===================================================== -->
+	<!-- ===================================================== -->
+	<!-- === Dictionary and Definition components === -->
+	<!-- ===================================================== -->
+	<element name="Definition" type="gml:DefinitionType" substitutionGroup="gml:_GML"/>
+	<!-- ===================================================== -->
+	<complexType name="DefinitionType">
+		<annotation>
+			<documentation>A definition, which can be included in or referenced by a dictionary. In this extended type, the inherited "description" optional element can hold the definition whenever only text is needed. The inherited "name" elements can provide one or more brief terms for which this is the definition. The inherited "metaDataProperty" elements can be used to reference or include more information about this definition.  
+The gml:id attribute is required - it must be possible to reference this definition using this handle.  </documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:AbstractGMLType">
+				<sequence>
+					<element ref="gml:description" minOccurs="0"/>
+					<element ref="gml:name" maxOccurs="unbounded"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- ===================================================== -->
+	<element name="Dictionary" type="gml:DictionaryType" substitutionGroup="gml:Definition"/>
+	<!-- ===================================================== -->
+	<complexType name="DictionaryType">
+		<annotation>
+			<documentation>A non-abstract bag that is specialized for use as a dictionary which contains a set of definitions. These definitions are referenced from other places, in the same and different XML documents. In this restricted type, the inherited optional "description" element can be used for a description of this dictionary. The inherited optional "name" element can be used for the name(s) of this dictionary. The inherited "metaDataProperty" elements can be used to reference or contain more information about this dictionary. The inherited required gml:id attribute allows the dictionary to be referenced using this handle. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:DefinitionType">
+				<sequence minOccurs="0" maxOccurs="unbounded">
+					<choice>
+						<element ref="gml:dictionaryEntry">
+							<annotation>
+								<documentation>An entry in this dictionary. The content of an entry can itself be a lower level dictionary or definition collection. This element follows the standard GML property model, so the value may be provided directly or by reference. Note that if the value is provided by reference, this definition does not carry a handle (gml:id) in this context, so does not allow external references to this specific entry in this context. When used in this way the referenced definition will usually be in a dictionary in the same XML document. </documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- ===================================================== -->
+	<element name="dictionaryEntry" type="gml:DictionaryEntryType"/>
+	<!-- ===================================================== -->
+	<complexType name="DictionaryEntryType">
+		<annotation>
+			<documentation>An entry in a dictionary of definitions. An instance of this type contains one definition object. Specialized descendents of this dictionaryEntry might be restricted in an application schema to allow only including specified types of definitions as valid entries in a dictionary. </documentation>
+			<documentation>An entry in a dictionary of definitions. An instance of this type contains one definition object. Specialized descendents of this dictionaryEntry might be restricted in an application schema to allow only including specified types of definitions as valid entries in a dictionary. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:Definition">
+				<annotation>
+					<documentation>This element in a dictionary entry contains the actual definition. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/geometryBasic0d1d.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/geometryBasic0d1d.xsd
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:geometryBasic0d1d:v3.1.1"/>
+		<documentation>Subset of geometryBasic0d1d.xsd for WCS 1.2 profile. 
+		Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-11-28
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ============================================================ -->
+	<include schemaLocation="measures.xsd"/>
+	<include schemaLocation="gmlBase.xsd"/>
+	<!-- ============================================================ -->
+	<!-- ===========  abstract supertype for geometry objects =================== -->
+	<!-- ============================================================ -->
+	<element name="_Geometry" type="gml:AbstractGeometryType" abstract="true" substitutionGroup="gml:_GML">
+		<annotation>
+			<documentation>The "_Geometry" element is the abstract head of the substituition group for all geometry elements of GML 3. This includes pre-defined and user-defined geometry elements. Any geometry element must be a direct or indirect extension/restriction of AbstractGeometryType and must be directly or indirectly in the substitution group of "_Geometry".</documentation>
+		</annotation>
+	</element>
+	<!-- ============================================================ -->
+	<complexType name="AbstractGeometryType" abstract="true">
+		<annotation>
+			<documentation>All geometry elements are derived directly or indirectly from this abstract supertype. A geometry element may have an identifying attribute ("gml:id"), a name (attribute "name") and a description (attribute "description"). It may be associated with a spatial reference system (attribute "srsName"). The following rules shall be adhered: - Every geometry type shall derive from this abstract type. - Every geometry element (i.e. an element of a geometry type) shall be directly or indirectly in the substitution group of _Geometry.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractGMLType">
+				<attributeGroup ref="gml:SRSReferenceGroup"/>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- ============================================================ -->
+	<attributeGroup name="SRSReferenceGroup">
+		<annotation>
+			<documentation>Optional reference to the CRS used by this geometry.</documentation>
+		</annotation>
+		<attribute name="srsName" type="anyURI" use="optional">
+			<annotation>
+				<documentation>In general this reference points to a CRS instance of gml:CoordinateReferenceSystemType (see coordinateReferenceSystems.xsd). For well known references it is not required that the CRS description exists at the location the URI points to.</documentation>
+			</annotation>
+		</attribute>
+	</attributeGroup>
+	<!-- ============================================================ -->
+	<element name="_GeometricPrimitive" type="gml:AbstractGeometricPrimitiveType" abstract="true" substitutionGroup="gml:_Geometry">
+		<annotation>
+			<documentation>The "_GeometricPrimitive" element is the abstract head of the substituition group for all (pre- and user-defined) geometric primitives.</documentation>
+		</annotation>
+	</element>
+	<!-- ============================================================== -->
+	<complexType name="AbstractGeometricPrimitiveType" abstract="true">
+		<annotation>
+			<documentation>This is the abstract root type of the geometric primitives. A geometric primitive is a geometric object that is not decomposed further into other primitives in the system. All primitives are oriented in the direction implied by the sequence of their coordinate tuples.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractGeometryType"/>
+		</complexContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<!-- positions -->
+	<!-- =========================================================== -->
+	<element name="pos" type="gml:DirectPositionType"/>
+	<!-- =========================================================== -->
+	<complexType name="DirectPositionType">
+		<annotation>
+			<documentation>DirectPosition instances hold the coordinates for a position within some coordinate reference system (CRS). Since DirectPositions, as data types, will often be included in larger objects (such as geometry elements) that have references to CRS, the "srsName" attribute will in general be missing, if this particular DirectPosition is included in a larger element with such a reference to a CRS. In this case, the CRS is implicitly assumed to take on the value of the containing object's CRS.</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="gml:doubleList">
+				<attributeGroup ref="gml:SRSReferenceGroup"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<element name="posList" type="gml:DirectPositionListType"/>
+	<!-- =========================================================== -->
+	<complexType name="DirectPositionListType">
+		<annotation>
+			<documentation>DirectPositionList instances hold the coordinates for a sequence of direct positions within the same coordinate reference system (CRS).</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="gml:doubleList">
+				<attributeGroup ref="gml:SRSReferenceGroup"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<!-- Envelope -->
+	<!-- =========================================================== -->
+	<element name="Envelope" type="gml:EnvelopeType"/>
+	<!-- =========================================================== -->
+	<complexType name="EnvelopeType">
+		<annotation>
+			<documentation>Envelope defines an extent using a pair of positions defining opposite corners in arbitrary dimensions. The first direct position is the "lower corner" (a coordinate position consisting of all the minimal ordinates for each dimension for all points within the envelope), the second one the "upper corner" (a coordinate position consisting of all the maximal ordinates for each dimension for all points within the envelope).</documentation>
+		</annotation>
+		<choice>
+			<sequence>
+				<element name="lowerCorner" type="gml:DirectPositionType"/>
+				<element name="upperCorner" type="gml:DirectPositionType"/>
+			</sequence>
+		</choice>
+		<attributeGroup ref="gml:SRSReferenceGroup"/>
+	</complexType>
+	<!-- =========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/geometryBasic2d.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/geometryBasic2d.xsd
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd::3.1.1">geometryBasic2d.xsd</appinfo>
+		<documentation>Subset of geometryBasic2d.xsd for WCS 1.2 profile. Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-04-23 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- =========================================================== -->
+	<include schemaLocation="geometryBasic0d1d.xsd"/>
+	<!-- =========================================================== -->
+	<!-- primitive geometry objects (2-dimensional) -->
+	<!-- =========================================================== -->
+	<element name="_Surface" type="gml:AbstractSurfaceType" abstract="true" substitutionGroup="gml:_GeometricPrimitive">
+		<annotation>
+			<documentation>The "_Surface" element is the abstract head of the substituition group for all (continuous) surface elements.</documentation>
+		</annotation>
+	</element>
+	<!-- =========================================================== -->
+	<complexType name="AbstractSurfaceType">
+		<annotation>
+			<documentation>An abstraction of a surface to support the different levels of complexity. A surface is always a continuous region of a plane.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractGeometricPrimitiveType"/>
+		</complexContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<element name="Polygon" type="gml:PolygonType" substitutionGroup="gml:_Surface"/>
+	<!-- =========================================================== -->
+	<complexType name="PolygonType">
+		<annotation>
+			<documentation>A Polygon is a special surface that is defined by a single surface patch. The boundary of this patch is coplanar and the polygon uses planar interpolation in its interior. It is backwards compatible with the Polygon of GML 2, GM_Polygon of ISO 19107 is implemented by PolygonPatch.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractSurfaceType">
+				<sequence>
+					<element ref="gml:exterior" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<!-- rings (closed curves for surface boundaries) -->
+	<!-- =========================================================== -->
+	<element name="_Ring" type="gml:AbstractRingType" abstract="true" substitutionGroup="gml:_Geometry">
+		<annotation>
+			<documentation>The "_Ring" element is the abstract head of the substituition group for all closed boundaries of a surface patch.</documentation>
+		</annotation>
+	</element>
+	<!-- =========================================================== -->
+	<complexType name="AbstractRingType" abstract="true">
+		<annotation>
+			<documentation>An abstraction of a ring to support surface boundaries of different complexity.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractGeometryType"/>
+		</complexContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<element name="exterior" type="gml:AbstractRingPropertyType">
+		<annotation>
+			<documentation>A boundary of a surface consists of a number of rings. In the normal 2D case, one of these rings is distinguished as being the exterior boundary. In a general manifold this is not always possible, in which case all boundaries shall be listed as interior boundaries, and the exterior will be empty.</documentation>
+		</annotation>
+	</element>
+	<!-- =========================================================== -->
+	<complexType name="AbstractRingPropertyType">
+		<annotation>
+			<documentation>Encapsulates a ring to represent the surface boundary property of a surface.</documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:_Ring"/>
+		</sequence>
+	</complexType>
+	<!-- =========================================================== -->
+	<element name="LinearRing" type="gml:LinearRingType" substitutionGroup="gml:_Ring"/>
+	<!-- =========================================================== -->
+	<complexType name="LinearRingType">
+		<annotation>
+			<documentation>A LinearRing is defined by four or more coordinate tuples, with linear interpolation between them; the first and last coordinates must be coincident.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractRingType">
+				<sequence>
+					<element ref="gml:posList">
+						<annotation>
+							<documentation>The "posList" element provides a compact way to specifiy the coordinates of the control points, assuming all control points are in the same coordinate reference systems. The number of direct positions in the list must be at least four.</documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/gmlBase.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/gmlBase.xsd
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:gmlBase:3.1.1"/>
+		<documentation>Subset of gmlBase.xsd for WCS 1.2 profile. Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-04-23 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved.</documentation>
+	</annotation>
+	<!-- ==============================================================
+       includes and imports
+	============================================================== -->
+	<include schemaLocation="basicTypes.xsd"/>
+	<import namespace="http://www.w3.org/1999/xlink" schemaLocation="../../../xlink/1.0.0/xlinks.xsd"/>
+	<!-- =========================================================== -->
+	<!-- ==================== Objects ================================ -->
+	<!-- =========================================================== -->
+	<!-- =========== Abstract "Object" is "anyType" ============= -->
+	<!-- ===== Global element at the head of the "Object" substitution group ======== -->
+	<element name="_Object" abstract="true">
+		<annotation>
+			<documentation>This abstract element is the head of a substitutionGroup hierararchy which may contain either simpleContent or complexContent elements.  It is used to assert the model position of "class" elements declared in other GML schemas.</documentation>
+		</annotation>
+	</element>
+	<!-- ============================================================= -->
+	<!-- =========== Abstract "GMLobject" supertype ========================= -->
+	<element name="_GML" type="gml:AbstractGMLType" abstract="true" substitutionGroup="gml:_Object">
+		<annotation>
+			<documentation>Global element which acts as the head of a substitution group that may include any element which is a GML feature, object, geometry or complex value</documentation>
+		</annotation>
+	</element>
+	<!-- =========================================================== -->
+	<group name="StandardObjectProperties">
+		<annotation>
+			<documentation>This content model group makes it easier to construct types that derive from AbstractGMLType and its descendents "by restriction".  A reference to the group saves having to enumerate the standard object properties.</documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:description" minOccurs="0"/>
+			<element ref="gml:name" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Multiple names may be provided.  These will often be distinguished by being assigned by different authorities, as indicated by the value of the codeSpace attribute.  In an instance document there will usually only be one name per authority.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</group>
+	<!-- =========================================================== -->
+	<complexType name="AbstractGMLType" abstract="true">
+		<annotation>
+			<documentation>All complexContent GML elements are directly or indirectly derived from this abstract supertype to establish a hierarchy of GML types that may be distinguished from other XML types by their ancestry. Elements in this hierarchy may have an ID and are thus referenceable.</documentation>
+		</annotation>
+		<sequence>
+			<group ref="gml:StandardObjectProperties"/>
+		</sequence>
+		<attribute ref="gml:id" use="optional"/>
+	</complexType>
+	<!-- =========================================================== -->
+	<!-- ================== Base Property Types ========================= -->
+	<!-- =========================================================== -->
+	<complexType name="ReferenceType">
+		<annotation>
+			<documentation>A pattern or base for derived types used to specify complex types corresponding to a UML aggregation association.  An instance of this type serves as a pointer to a remote Object.</documentation>
+		</annotation>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =========================================================== -->
+	<!-- ==========================================================
+	global attribute, attribute group and element declarations 
+	============================================================  -->
+	<attribute name="id" type="ID">
+		<annotation>
+			<documentation>Database handle for the object.  It is of XML type ID, so is constrained to be unique in the XML document within which it occurs.  An external identifier for the object in the form of a URI may be constructed using standard XML and XPointer methods.  This is done by concatenating the URI for the document, a fragment separator, and the value of the id attribute.</documentation>
+		</annotation>
+	</attribute>
+	<!-- =========================================================== -->
+	<attributeGroup name="AssociationAttributeGroup">
+		<annotation>
+			<documentation>Attribute group used to enable property elements to refer to their value remotely. It contains the simple link components from xlinks.xsd, with all members optional, and the remoteSchema attribute, which is also optional.  These attributes can be attached to any element, thus allowing it to act as a pointer. The 'remoteSchema' attribute allows an element  that carries link attributes to indicate that the element is declared  in a remote schema rather than by the schema that constrains the current document instance.</documentation>
+		</annotation>
+		<attributeGroup ref="xlink:simpleLink"/>
+	</attributeGroup>
+	<!-- =========================================================== -->
+	<element name="name" type="gml:CodeType">
+		<annotation>
+			<documentation>Label for the object, normally a descriptive name. An object may have several names, typically assigned by different authorities.  The authority for a name is indicated by the value of its (optional) codeSpace attribute.  The name may or may not be unique, as determined by the rules of the organization responsible for the codeSpace.</documentation>
+		</annotation>
+	</element>
+	<!-- =========================================================== -->
+	<element name="description" type="string">
+		<annotation>
+			<documentation>Contains a simple text description of the object.</documentation>
+			<documentation>Restricted to only allow a text string, as done in GML 3.2. </documentation>
+		</annotation>
+	</element>
+	<!-- ===================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/measures.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/measures.xsd
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" elementFormDefault="qualified" attributeFormDefault="unqualified" version="3.1.1" xml:lang="en" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-measures:3.1.1"/>
+		<documentation>Subset of measures.xsd for WCS 1.2 profile. Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-05-15 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+       includes and imports
+	============================================================== -->
+	<include schemaLocation="units.xsd"/>
+	<!-- ==============================================================
+       elements and types
+	============================================================== -->
+	<!-- This schema uses the gml:MeasureType defined in basicTypes.xsd with the modified meaning:
+			<documentation>Value of a quantity, with its units. This element uses the XML Schema primitive data type "double" because it supports both decimal and scientific notation, and thus offers flexibility and precision. However, there is no requirement to store values using any particular format, and applications receiving elements of this type may choose to coerce the data to any other type as convenient. The XML attribute uom references the units or scale by which the amount should be multiplied. For a reference within the same XML document, the abbreviated XPointer prefix "#" symbol should be used, followed by a text abbreviation of the unit name. However, the "#" symbol may be optional, and still may be interpreted as a reference. </documentation> -->
+	<!-- =========================================================== -->
+	<element name="measure" type="gml:MeasureType"/>
+	<!-- =========================================================== -->
+	<complexType name="LengthType">
+		<annotation>
+			<documentation>Value of a length (or distance) quantity, with its units. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for a length, such as metres or feet.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="ScaleType">
+		<annotation>
+			<documentation>Value of a scale factor (or ratio) that has no physical unit. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for a scale factor, such as percent, permil, or parts-per-million.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="TimeType">
+		<annotation>
+			<documentation>Value of a time or temporal quantity, with its units. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for a time value, such as seconds or weeks.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="GridLengthType">
+		<annotation>
+			<documentation>Value of a length (or distance) quantity in a grid, where the grid spacing does not have any associated physical units, or does not have a constant physical spacing. This grid length will often be used in a digital image grid, where the base units are likely to be pixel spacings. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for length along the axes of a grid, such as pixel spacings or grid spacings.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="AreaType">
+		<annotation>
+			<documentation>Value of a spatial area quantity, with its units. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for an area, such as square metres or square miles.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="VolumeType">
+		<annotation>
+			<documentation>Value of a spatial volume quantity, with its units. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for a volume, such as cubic metres or cubic feet.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="SpeedType">
+		<annotation>
+			<documentation>Value of a speed, with its units. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for a velocity, such as metres per second or miles per hour.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="AngleChoiceType">
+		<annotation>
+			<documentation>Value of an angle quantity provided in either degree-minute-second format or single value format.</documentation>
+		</annotation>
+		<choice>
+			<element ref="gml:angle"/>
+			<!-- <element ref="gml:dmsAngle"/> -->
+		</choice>
+	</complexType>
+	<!-- =========================================================== -->
+	<element name="angle" type="gml:MeasureType"/>
+	<!-- =========================================================== -->
+	<complexType name="AngleType">
+		<annotation>
+			<documentation>Value of an angle quantity recorded as a single number, with its units. Uses the MeasureType with the restriction that the unit of measure referenced by uom must be suitable for an angle, such as degrees or radians.</documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="gml:MeasureType"/>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<!-- <element name="dmsAngle" type="gml:DMSAngleType"/> -->
+	<!-- =========================================================== -->
+	<!-- <complexType name="DMSAngleType">
+		<annotation>
+			<documentation>Angle value provided in degree-minute-second or degree-minute format.</documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:degrees"/>
+			<choice minOccurs="0">
+				<element ref="gml:decimalMinutes"/>
+				<sequence>
+					<element ref="gml:minutes"/>
+					<element ref="gml:seconds" minOccurs="0"/>
+				</sequence>
+			</choice>
+		</sequence>
+	</complexType> -->
+	<!-- =========================================================== -->
+	<!-- <element name="degrees" type="gml:DegreesType"/> -->
+	<!-- =========================================================== -->
+	<!-- <complexType name="DegreesType">
+		<annotation>
+			<documentation>Integer number of degrees, plus the angle direction. This element can be used for geographic Latitude and Longitude. For Latitude, the XML attribute direction can take the values "N" or "S", meaning North or South of the equator. For Longitude, direction can take the values "E" or "W", meaning East or West of the prime meridian. This element can also be used for other angles. In that case, the direction can take the values "+" or "-" (of SignType), in the specified rotational direction from a specified reference direction.</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="gml:DegreeValueType">
+				<attribute name="direction">
+					<simpleType>
+						<union>
+							<simpleType>
+								<restriction base="string">
+									<enumeration value="N"/>
+									<enumeration value="E"/>
+									<enumeration value="S"/>
+									<enumeration value="W"/>
+								</restriction>
+							</simpleType>
+							<simpleType>
+								<restriction base="gml:SignType"/>
+							</simpleType>
+						</union>
+					</simpleType>
+				</attribute>
+			</extension>
+		</simpleContent>
+	</complexType> -->
+	<!-- =========================================================== -->
+	<!-- <simpleType name="DegreeValueType">
+		<annotation>
+			<documentation>Integer number of degrees in a degree-minute-second or degree-minute angular value, without indication of direction.</documentation>
+		</annotation>
+		<restriction base="nonNegativeInteger">
+			<maxInclusive value="359"/>
+		</restriction>
+	</simpleType> -->
+	<!-- =========================================================== -->
+	<!-- <element name="decimalMinutes" type="gml:DecimalMinutesType"/> -->
+	<!-- =========================================================== -->
+	<!-- <simpleType name="DecimalMinutesType">
+		<annotation>
+			<documentation>Decimal number of arc-minutes in a degree-minute angular value.</documentation>
+		</annotation>
+		<restriction base="decimal">
+			<minInclusive value="0.00"/>
+			<maxExclusive value="60.00"/>
+		</restriction>
+	</simpleType> -->
+	<!-- =========================================================== -->
+	<!-- <element name="minutes" type="gml:ArcMinutesType"/> -->
+	<!-- =========================================================== -->
+	<!-- <simpleType name="ArcMinutesType">
+		<annotation>
+			<documentation>Integer number of arc-minutes in a degree-minute-second angular value.</documentation>
+		</annotation>
+		<restriction base="nonNegativeInteger">
+			<maxInclusive value="59"/>
+		</restriction>
+	</simpleType> -->
+	<!-- =========================================================== -->
+	<!-- <element name="seconds" type="gml:ArcSecondsType"/> -->
+	<!-- =========================================================== -->
+	<!-- <simpleType name="ArcSecondsType">
+		<annotation>
+			<documentation>Number of arc-seconds in a degree-minute-second angular value.</documentation>
+		</annotation>
+		<restriction base="decimal">
+			<minInclusive value="0.00"/>
+			<maxExclusive value="60.00"/>
+		</restriction>
+	</simpleType> -->
+	<!-- =========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/referenceSystems.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/referenceSystems.xsd
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:referenceSystems:3.1.1"/>
+		<documentation>Subset of referenceSystems.xsd for WCS 1.2 profile. Primary editor: Arliss Whiteside. Last updated 2007-04-23. 
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ======================================================
+       includes and imports
+	====================================================== -->
+	<include schemaLocation="dictionary.xsd"/>
+	<include schemaLocation="geometryBasic2d.xsd"/>
+	<!-- ======================================================
+       elements and types
+	====================================================== -->
+	<element name="_ReferenceSystem" type="gml:AbstractReferenceSystemType" abstract="true" substitutionGroup="gml:Definition"/>
+	<!-- =================================================== -->
+	<complexType name="AbstractReferenceSystemBaseType" abstract="true">
+		<annotation>
+			<documentation>Basic encoding for reference system objects, simplifying and restricting the DefinitionType as needed.</documentation>
+		</annotation>
+		<complexContent>
+			<restriction base="gml:DefinitionType">
+				<sequence>
+					<element ref="gml:srsName"/>
+				</sequence>
+				<attribute ref="gml:id" use="required"/>
+			</restriction>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="srsName" type="gml:CodeType" substitutionGroup="gml:name">
+		<annotation>
+			<documentation>The name by which this reference system is identified.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="AbstractReferenceSystemType" abstract="true">
+		<annotation>
+			<documentation>Description of a spatial and/or temporal reference system used by a dataset.</documentation>
+		</annotation>
+		<complexContent>
+			<extension base="gml:AbstractReferenceSystemBaseType">
+				<sequence>
+					<element ref="gml:srsID" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Set of alterative identifications of this reference system. The first srsID, if any, is normally the primary identification code, and any others are aliases.</documentation>
+						</annotation>
+					</element>
+					<element ref="gml:remarks" minOccurs="0">
+						<annotation>
+							<documentation>Comments on or information about this reference system, including source information.</documentation>
+						</annotation>
+					</element>
+					<element ref="gml:validArea" minOccurs="0"/>
+					<element ref="gml:scope" minOccurs="0"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="srsID" type="gml:IdentifierType">
+		<annotation>
+			<documentation>An identification of a reference system.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="ReferenceSystemRefType">
+		<annotation>
+			<documentation>Association to a reference system, either referencing or containing the definition of that reference system.</documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_ReferenceSystem"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="_CRS" type="gml:AbstractReferenceSystemType" abstract="true" substitutionGroup="gml:_ReferenceSystem">
+		<annotation>
+			<documentation>Abstract coordinate reference system, usually defined by a coordinate system and a datum. This abstract complexType shall not be used, extended, or restricted, in an Application Schema, to define a concrete subtype with a meaning equivalent to a concrete subtype specified in this document.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="CRSRefType">
+		<annotation>
+			<documentation>Association to a CRS abstract coordinate reference system, either referencing or containing the definition of that CRS.</documentation>
+		</annotation>
+		<sequence minOccurs="0">
+			<element ref="gml:_CRS"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- =================================================== -->
+	<!-- =================================================== -->
+	<complexType name="IdentifierType">
+		<annotation>
+			<documentation>An identification of a CRS object. The first use of the IdentifierType for an object, if any, is normally the primary identification code, and any others are aliases.</documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:name">
+				<annotation>
+					<documentation>The code or name for this Identifier, often from a controlled list or pattern defined by a code space. The optional codeSpace attribute is normally included to identify or reference a code space within which one or more codes are defined. This code space is often defined by some authority organization, where one organization may define multiple code spaces. The range and format of each Code Space identifier is defined by that code space authority. Information about that code space authority can be included as metaDataProperty elements which are optionally allowed in all CRS objects.</documentation>
+				</annotation>
+			</element>
+			<element ref="gml:version" minOccurs="0"/>
+			<element ref="gml:remarks" minOccurs="0">
+				<annotation>
+					<documentation>Remarks about this code or alias.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="version" type="string">
+		<annotation>
+			<documentation>Identifier of the version of the associated codeSpace or code, as specified by the codeSpace or code authority. This version is included only when the "code" or "codeSpace" uses versions. When appropriate, the version is identified by the effective date, coded using ISO 8601 date format.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="remarks" type="string">
+		<annotation>
+			<documentation>Information about this object or code. </documentation>
+			<documentation>Restricted to only allow a text string, as done in GML 3.2. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="scope" type="string">
+		<annotation>
+			<documentation>Description of domain of usage, or limitations of usage, for which this CRS object is valid.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="validArea" type="gml:ExtentType">
+		<annotation>
+			<documentation>Area or region in which this CRS object is valid.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<complexType name="ExtentType">
+		<annotation>
+			<documentation>Information about the spatial, vertical, and/or temporal extent of a reference system object. Constraints: At least one of the elements "description", "boundingBox", "boundingPolygon", "verticalExtent", and temporalExtent" must be included, but more that one can be included when appropriate. Furthermore, more than one "boundingBox", "boundingPolygon", "verticalExtent", and/or temporalExtent" element can be included, with more than one meaning the union of the individual domains.</documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:description" minOccurs="0">
+				<annotation>
+					<documentation>Description of spatial and/or temporal extent of this object.</documentation>
+				</annotation>
+			</element>
+			<choice>
+				<annotation>
+					<documentation>Geographic domain of this reference system object.</documentation>
+				</annotation>
+				<element ref="gml:boundingBox" minOccurs="0" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of bounding boxes (or envelopes) whose union describes the spatial domain of this object.</documentation>
+					</annotation>
+				</element>
+				<element ref="gml:boundingPolygon" minOccurs="0" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of bounding polygons whose union describes the spatial domain of this object.</documentation>
+					</annotation>
+				</element>
+			</choice>
+			<element ref="gml:verticalExtent" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Unordered list of vertical intervals whose union describes the spatial domain of this object.</documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="boundingBox" type="gml:EnvelopeType">
+		<annotation>
+			<documentation>A bounding box (or envelope) defining the spatial domain of this object.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="boundingPolygon" type="gml:PolygonType">
+		<annotation>
+			<documentation>A bounding polygon defining the horizontal spatial domain of this object.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="verticalExtent" type="gml:EnvelopeType">
+		<annotation>
+			<documentation>An interval defining the vertical spatial domain of this object.</documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/temporal.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/temporal.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:temporal:3.1.1"/>
+		<documentation>Subset of temporal.xsd for WCS 1.2 profile. Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-04-23.
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved.</documentation>
+	</annotation>
+	<!-- ======== includes and imports =================================== -->
+	<include schemaLocation="gmlBase.xsd"/>
+	<!-- =========================================================== -->
+	<!-- ==== Time Position ===== -->
+	<!-- =========================================================== -->
+	<element name="timePosition" type="gml:TimePositionType">
+		<annotation>
+			<documentation>Direct representation of a temporal position</documentation>
+		</annotation>
+	</element>
+	<!-- =========================================================== -->
+	<complexType name="TimePositionType" final="#all">
+		<annotation>
+			<documentation>Direct representation of a temporal position. 
+      Indeterminate time values are also allowed, as described in ISO 19108. The 
+      indeterminatePosition attribute can be used alone or it can qualify a specific value for temporal 
+      position (e.g. before 2002-12, after 1019624400). 
+      For time values that identify position within a calendar, the calendarEraName attribute provides 
+      the name of the calendar era to which the date is referenced (e.g. the Meiji era of the 
+      Japanese calendar).</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="gml:TimePositionUnion">
+				<attribute name="frame" type="anyURI" use="optional" default="#ISO-8601"/>
+				<attribute name="calendarEraName" type="string" use="optional"/>
+				<attribute name="indeterminatePosition" type="gml:TimeIndeterminateValueType" use="optional"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<!-- =========================================================== -->
+	<simpleType name="TimePositionUnion">
+		<annotation>
+			<documentation>The ISO 19108:2002 hierarchy of subtypes for temporal position are  
+      collapsed by defining a union of XML Schema simple types for indicating temporal position  
+      relative to a specific reference system. 
+      
+      Dates and dateTime may be indicated with varying degrees of precision.  
+      dateTime by itself does not allow right-truncation, except for fractions of seconds. 
+      When used with non-Gregorian calendars based on years, months, days, 
+      the same lexical representation should still be used, with leading zeros added if the 
+      year value would otherwise have fewer than four digits.  
+      
+      An ordinal position may be referenced via URI identifying the definition of an ordinal era.  
+      
+      A time coordinate value is indicated as a decimal (e.g. UNIX time, GPS calendar).</documentation>
+		</annotation>
+		<union memberTypes="gml:CalDate time dateTime anyURI decimal"/>
+	</simpleType>
+	<!-- =========================================================== -->
+	<simpleType name="CalDate">
+		<annotation>
+			<documentation>Calendar dates may be indicated with varying degrees of precision, 
+      using year, year-month, date. 
+      When used with non-Gregorian calendars based on years, months, days, 
+      the same lexical representation should still be used, with leading zeros added if the 
+      year value would otherwise have fewer than four digits.  
+      time is used for a position that recurs daily (see clause 5.4.4.2 of ISO 19108:2002).</documentation>
+		</annotation>
+		<union memberTypes="date gYearMonth gYear"/>
+	</simpleType>
+	<!-- =========================================================== -->
+	<simpleType name="TimeIndeterminateValueType">
+		<annotation>
+			<documentation xml:lang="en">This enumerated data type specifies values for indeterminate positions.</documentation>
+		</annotation>
+		<restriction base="string">
+			<enumeration value="after"/>
+			<enumeration value="before"/>
+			<enumeration value="now"/>
+			<enumeration value="unknown"/>
+		</restriction>
+	</simpleType>
+	<!-- ============================================================ -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/units.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GMLprofileForWCS/units.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="3.1.1" xml:lang="en">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-units:3.1.1"/>
+		<documentation>Subset of units.xsd for WCS 1.2 profile. Primary editor: Primary editor: Arliss Whiteside. Last updated 2007-04-23.
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved.</documentation>
+	</annotation>
+	<!-- ==============================================================
+       includes and imports
+	============================================================== -->
+	<include schemaLocation="basicTypes.xsd"/>
+	<!-- ==============================================================
+       elements and types
+	============================================================== -->
+	<element name="unitOfMeasure" type="gml:UnitOfMeasureType"/>
+	<!-- =========================================================== -->
+	<complexType name="UnitOfMeasureType">
+		<annotation>
+			<documentation>Reference to a unit of measure definition that applies to all the numerical values described by the element containing this element. Notice that a complexType which needs to include the uom attribute can do so by extending this complexType. Alternately, this complexType can be used as a pattern for a new complexType.</documentation>
+		</annotation>
+		<sequence/>
+		<attribute name="uom" type="anyURI" use="required">
+			<annotation>
+				<documentation>Reference to a unit of measure definition, usually within the same XML document but possibly outside the XML document which contains this reference. For a reference within the same XML document, the "#" symbol should be used, followed by a text abbreviation of the unit name. However, the "#" symbol may be optional, and still may be interpreted as a reference.</documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<!-- =========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GridMethods/2dGridIn2dCrsMethod.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GridMethods/2dGridIn2dCrsMethod.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OperationMethod xmlns="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/gml ../../../gml/3.1.1/profiles/GridCRSs/1.0.0/gmlGridCRSsProfile.xsd" 
+gml:id="grid2dIn2dCrsMethod">
+	<!-- Last updated 2007-06-06 -->
+	<!-- =============================================== -->
+	<methodName>2D Rectified Grid in 2D CRS Method</methodName>
+	<methodID>
+		<name>urn:ogc:def:method:WCS:1.1:2dGridIn2dCrs</name>
+	</methodID>
+	<remarks>Method for use by a Coordinate Conversion defining a 2D GridCRS in a 2D baseCRS, based on CV_RectifiedGrid in ISO 19123 so the grid can be rotated and skewed in this baseCRS. </remarks>
+	<methodFormula>The reverse direction (from the grid CRS to the baseCRS) shall be as specified by the equations:
+	BaseX = origin(1) + offsets(1,1) * GridX + offsets(1,2) * GridY
+	BaseY = origin(2) + offsets(2,1) * GridX + offsets(2,2) * GridY
+where 
+	GridX, GridY are position coordinates in the grid 2D CRS
+	BaseX, BaseY are position coordinates in the 2D base CRS
+	origin(1), origin(2) are the two coordinates of the grid origin position in the 2D base CRS
+	offsets(1,1), offsets(1,2) are the grid point offsets of the first grid axis in the 2D base CRS
+	offsets(2,1), offsets(2,2) are the grid point offsets of the second grid axis in the 2D base CRS
+
+The forward direction (from the baseCRS to the GridCRS) equations are not included here. </methodFormula>
+	<sourceDimensions>2</sourceDimensions>
+	<targetDimensions>2</targetDimensions>
+	<!-- =============================================== -->
+	<usesParameter>
+		<OperationParameter gml:id="origin2d">
+			<parameterName>origin2d</parameterName>
+			<parameterID>
+				<name>urn:ogc:def:parameter:WCS:1.1:origin2d</name>
+			</parameterID>
+			<remarks>This parameter shall be encoded as a wcs:Origin element, giving the two origin coordinates in the 2D base CRS of this GridCRS. </remarks>
+		</OperationParameter>
+	</usesParameter>
+	<!-- =============================================== -->
+	<usesParameter>
+		<OperationParameter gml:id="offsets2d">
+			<parameterName>offsets2d</parameterName>
+			<parameterID>
+				<name>urn:ogc:def:parameter:WCS:1.1:offsets2d</name>
+			</parameterID>
+			<remarks>This parameter shall be encoded as a wcs:Offsets element, giving the grid offsets in the two grid axes, each in the 2D base CRS relative to the specified origin. This wcs:Offsets shall contain four values, the first two values shall specify the grid offset for the first grid axis, and the second pair of values shall specify the grid offset for the second grid axis. </remarks>
+		</OperationParameter>
+	</usesParameter>
+</OperationMethod>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GridMethods/2dGridIn3dCRsMethod.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GridMethods/2dGridIn3dCRsMethod.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OperationMethod xmlns="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/gml ../../../gml/3.1.1/profiles/GridCRSs/1.0.0/gmlGridCRSsProfile.xsd" 
+gml:id="grid2dIn3dMethod">
+	<!-- Last updated 2006-02-28 -->
+	<!-- =============================================== -->
+	<methodName>2D Rectified Grid in 3D CRS Method</methodName>
+	<methodID>
+		<name>urn:ogc:def:method:WCS:1.1:2dGridIn3dCrs</name>
+	</methodID>
+	<remarks>Method for use by a Coordinate Conversion defining a 2D GridCRS in a 3D baseCRS, based on CV_RectifiedGrid in ISO 19123 so the grid can be rotated and skewed in this baseCRS. </remarks>
+	<methodFormula>The reverse direction (from the GridCRS to the baseCRS) shall be as specified by the equations:
+	BaseX = origin(1) + offsets(1,1) * GridX + offsets(2,1) * GridY
+	BaseY = origin(2) + offsets(1,2) * GridX + offsets(2,2) * GridY
+	BaseZ = origin(3) + offsets(1,3) * GridX + offsets(2,3) * GridY
+where 
+	GridX, GridY are position coordinates in the 2D grid CRS
+	BaseX, BaseY, BaseZ are position coordinates in the 3D base CRS
+	origin(1), origin(2), origin(3) are the three coordinates of the grid origin position in the 3D base CRS
+	offsets(1,1),offsets(1,2), offsets(1,3) are the grid spacings of the first grid axis in the 3D base CRS
+	offsets(2,1), offsets(2,2), offsets(2,3) are the grid spacings of the second grid axis in the 3D base CRS
+
+The forward direction (from the baseCRS to the GridCRS) equations are not included here. </methodFormula>
+	<sourceDimensions>3</sourceDimensions>
+	<targetDimensions>2</targetDimensions>
+	<!-- =============================================== -->
+	<usesParameter>
+		<OperationParameter gml:id="origin3d">
+			<parameterName>origin3d</parameterName>
+			<parameterID>
+				<name>urn:ogc:def:parameter:WCS:1.1:origin3d</name>
+			</parameterID>
+			<remarks>This parameter shall be encoded as a wcs:Origin element, giving the three origin coordinates in the 3D base CRS of this GridCRS. </remarks>
+		</OperationParameter>
+	</usesParameter>
+	<!-- =============================================== -->
+	<usesParameter>
+		<OperationParameter gml:id="offsets3d">
+			<parameterName>offsets3d</parameterName>
+			<parameterID>
+				<name>urn:ogc:def:parameter:WCS:1.1:offsets3d</name>
+			</parameterID>
+			<remarks>This parameter shall be encoded as a wcs:Offsets element, giving the grid offsets in the two grid axes, each in the 3D base CRS relative to the specified origin. This wcs:Offsets shall contain six values, the first three values shall specify the grid offset for the first grid axis, and the second three values shall specify the grid offset for the second grid axis. </remarks>
+		</OperationParameter>
+	</usesParameter>
+</OperationMethod>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/GridMethods/2dSimpleGridMethod.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/GridMethods/2dSimpleGridMethod.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OperationMethod xmlns="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/gml ../../../gml/3.1.1/profiles/GridCRSs/1.0.0/gmlGridCRSsProfile.xsd" 
+gml:id="grid2dIn2dCrsMethod">
+	<!-- Last updated 2007-06-06 -->
+	<!-- =============================================== -->
+	<methodName>2D Simple Grid Method</methodName>
+	<methodID>
+		<name>urn:ogc:def:method:WCS:1.1:2dSimpleGrid</name>
+	</methodID>
+	<remarks>Method for use by a Coordinate Conversion defining a simple 2D GridCRS in a 2D baseCRS, where this grid is not rotated or skewed in this baseCRS. </remarks>
+	<methodFormula>The reverse direction (from the grid CRS to the baseCRS) shall be as specified by the equations:
+	BaseX = origin(1) + offsets(1) * GridX
+	BaseY = origin(2) + offsets(2) * GridY
+where 
+	GridX, GridY are position coordinates in the grid 2D CRS
+	BaseX, BaseY are position coordinates in the 2D base CRS
+	origin(1), origin(2) are the two coordinates of the grid origin position in the 2D base CRS
+	offsets(1) is the grid point offsets of the first grid axis in the 2D base CRS
+	offsets(2) is the grid point offsets of the second grid axis in the 2D base CRS
+
+The forward direction (from the baseCRS to the GridCRS) equations are not included here. </methodFormula>
+	<sourceDimensions>2</sourceDimensions>
+	<targetDimensions>2</targetDimensions>
+	<!-- =============================================== -->
+	<usesParameter>
+		<OperationParameter gml:id="origin2d">
+			<parameterName>origin2d</parameterName>
+			<parameterID>
+				<name>urn:ogc:def:parameter:WCS:1.1:origin2d</name>
+			</parameterID>
+			<remarks>This parameter shall be encoded as a wcs:Origin element, giving the two origin coordinates in the 2D base CRS of this GridCRS. </remarks>
+		</OperationParameter>
+	</usesParameter>
+	<!-- =============================================== -->
+	<usesParameter>
+		<OperationParameter gml:id="offsets2d">
+			<parameterName>offsets2d</parameterName>
+			<parameterID>
+				<name>urn:ogc:def:parameter:WCS:1.1:offsets2d</name>
+			</parameterID>
+			<remarks>This parameter shall be encoded as a wcs:Offsets element, giving the grid offsets in the two grid axes, relative to the specified origin. This wcs:Offsets shall contain two values, the first value shall specify the grid offset for the first grid axis in the first baseCRS axis, and the second value shall specify the grid offset for the second grid axis in the second baseCRS axis. </remarks>
+		</OperationParameter>
+	</usesParameter>
+</OperationMethod>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/gml4wcs.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/gml4wcs.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml"
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1">
+	<annotation>
+		<appinfo source="urn:opengis:specification:gml:schema-xsd:gml:3.1.1">gml.xsd</appinfo>
+		<documentation>GML profile for WCS 1.2. Primary editor: Arliss Whiteside. Last updated 2007-06-06
+		Copyright © 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ============================================================== -->
+	<include schemaLocation="GMLprofileForWCS/coordinateOperations.xsd"/>
+	<include schemaLocation="GMLprofileForWCS/temporal.xsd"/>	
+	<include schemaLocation="GMLprofileForWCS/geometryBasic2d.xsd"/>	
+	<!-- ============================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/interpolationMethods.xml
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/interpolationMethods.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Dictionary xmlns="http://www.opengis.net/gml" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/gml ../../gml/3.1.1/profiles/SimpleDictionary/1.0.0/gmlSimpleDictionaryProfile.xsd" 
+gml:id="InterpolationMethods">
+	<!-- Primary editor: Arliss Whiteside. Last updated 2007-06-06 -->
+	<description>This dictionary specifies the standard values of interpolation types specified in the WCS 1.1 specification, based on ISO 19123. In addition, this dictionary specifies definition URNs in the "ogc URN namespace for these interpolation types. </description>
+	<name>Interpolation methods standard values</name>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="nearest">
+			<description>Identifier of nearest neighbour interpolation defined in Annex C of ISO 19123: Geographic information - Schema for coverage geometry and functions. </description>
+			<name>nearest</name>
+			<name>urn:ogc:def:interpolation:OGC:1.0:nearest</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="linear">
+			<description>Identifier of bilinear interpolation defined in Annex C of ISO 19123: Geographic information - Schema for coverage geometry and functions. ISO 19123 specifies two-dimensional bilinear, biquadratic, and bicubic interpolation types. When also interpolating in the elevation dimension of a 3D CRS, the 3D extensions of these interpolation types shall be used. </description>
+			<name>linear</name>
+			<name>urn:ogc:def:interpolation:OGC:1.0:linear</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="quadratic">
+			<description>Identifier of biquadratic interpolation defined in Annex C of ISO 19123: Geographic information - Schema for coverage geometry and functions. ISO 19123 specifies two-dimensional bilinear, biquadratic, and bicubic interpolation types. When also interpolating in the elevation dimension of a 3D CRS, the 3D extensions of these interpolation types shall be used. </description>
+			<name>quadratic</name>
+			<name>urn:ogc:def:interpolation:OGC:1.0:quadratic</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="cubic">
+			<description>Identifier of bicubic interpolation defined in Annex C of ISO 19123: Geographic information - Schema for coverage geometry and functions. ISO 19123 specifies two-dimensional bilinear, biquadratic, and bicubic interpolation types. When also interpolating in the elevation dimension of a 3D CRS, the 3D extensions of these interpolation types shall be used. </description>
+			<name>cubic</name>
+			<name>urn:ogc:def:interpolation:OGC:1.0:cubic</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="none">
+			<description>Identifier that no interpolation is available; requests must be for locations that are among the original domain locations. </description>
+			<name>none</name>
+			<name>urn:ogc:def:interpolation:OGC:1.0:none</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="full">
+			<description>Identifier that nulls in the input grid(s) have no effect on the interpolated value; resampling uses only non-null valued cells. </description>
+			<name>full</name>
+			<name>urn:ogc:def:nullResistance:OGC:1.0:full</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="zero">
+			<description>Identifier that interpolated value is Null if any one input value is Null. </description>
+			<name>zero</name>
+			<name>urn:ogc:def:nullResistance:OGC:1.0:zero</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="half">
+			<description>Identifier that interpolated value is Null if half or more of the input values are Null. </description>
+			<name>half</name>
+			<name>urn:ogc:def:nullResistance:OGC:1.0:half</name>
+		</Definition>
+	</dictionaryEntry>
+	<!-- ===================================================== -->
+	<dictionaryEntry>
+		<Definition gml:id="other">
+			<description>Identifier that resampling treats nulls differently from any method described above. </description>
+			<name>other</name>
+			<name>urn:ogc:def:nullResistance:OGC:1.0:other</name>
+		</Definition>
+	</dictionaryEntry>
+</Dictionary>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsAll.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsAll.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsAll.xsd 2007-06-06</appinfo>
+		<documentation>This XML Schema Document includes, directly and indirectly, all the XML Schema Documents defined by the OGC Web Coverage Service (WCS). 
+			Copyright (c) 2007 Open Geospatial Consortium, Inc, All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+           includes and imports
+	============================================================== -->
+	<include schemaLocation="wcsGetCoverage.xsd"/>
+	<include schemaLocation="wcsDescribeCoverage.xsd"/>
+	<include schemaLocation="wcsGetCapabilities.xsd"/>
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsCommon.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsCommon.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsContents.xsd 2007-06-06</appinfo>
+		<appinfo>
+			<GMLProfileSchema>http://schemas.opengis.net/wcs/1.1.1/gml4wcs.xsd</GMLProfileSchema>
+		</appinfo>
+		<documentation>This XML Schema Document encodes the elements and types that are shared by multiple WCS operations. 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc, All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+ 	includes and imports	
+	============================================================== -->
+	<import namespace="http://www.opengis.net/gml" schemaLocation="../../gml/3.1.1/base/gml.xsd"/>
+	<!-- ==============================================================		
+	elements and types	
+	============================================================== -->
+	<complexType name="RequestBaseType">
+		<annotation>
+			<documentation>XML encoded WCS operation request base, for all operations except GetCapabilities. In this XML encoding, no "request" parameter is included, since the element name specifies the specific operation. </documentation>
+		</annotation>
+		<sequence/>
+		<attribute name="service" type="string" use="required" fixed="WCS">
+			<annotation>
+				<documentation>Service type identifier, where the value is the OWS type abbreviation. For WCS operation requests, the value is "WCS". </documentation>
+			</annotation>
+		</attribute>
+		<attribute name="version" type="string" use="required" fixed="1.1.1">
+			<annotation>
+				<documentation>Specification version for WCS version and operation. See Version parameter Subclause 7.3.1 of OWS Common for more information. </documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<!-- =========================================================== -->
+	<element name="Identifier" type="wcs:IdentifierType"/>
+	<!-- =========================================================== -->
+	<simpleType name="IdentifierType">
+		<annotation>
+			<documentation>Unambiguous identifier. Although there is no formal restriction on characters included, these identifiers shall be directly usable in GetCoverage operation requests for the specific server, whether those requests are encoded in KVP or XML. Each of these encodings requires that certain characters be avoided, encoded, or escaped (TBR). </documentation>
+		</annotation>
+		<restriction base="string">
+			<pattern value=".+"/>
+		</restriction>
+	</simpleType>
+	<!-- =========================================================== -->
+	<complexType name="TimeSequenceType">
+		<annotation>
+			<documentation>List of time positions and periods. The time positions and periods should be ordered from the oldest to the newest, but this is not required. </documentation>
+		</annotation>
+		<choice maxOccurs="unbounded">
+			<element ref="gml:timePosition"/>
+			<element name="TimePeriod" type="wcs:TimePeriodType"/>
+		</choice>
+	</complexType>
+	<!-- ========================================================= -->
+	<complexType name="TimePeriodType">
+		<annotation>
+			<documentation>This is a variation of the GML TimePeriod, which allows the beginning and end of a time-period to be expressed in short-form inline using the begin/endPosition element, which allows an identifiable TimeInstant to be defined simultaneously with using it, or by reference, using xlinks on the begin/end elements. </documentation>
+			<documentation>(Arliss) What does this mean? What do the TimeResolution and "frame" mean? </documentation>
+		</annotation>
+		<sequence>
+			<element name="BeginPosition" type="gml:TimePositionType"/>
+			<element name="EndPosition" type="gml:TimePositionType"/>
+			<element name="TimeResolution" type="wcs:TimeDurationType" minOccurs="0"/>
+		</sequence>
+		<attribute name="frame" type="anyURI" use="optional" default="#ISO-8601"/>
+	</complexType>
+	<!-- ========================================================= -->
+	<simpleType name="TimeDurationType">
+		<annotation>
+			<documentation xml:lang="en">
+      Base type for describing temporal length or distance. The value space is further 
+      constrained by subtypes that conform to the ISO 8601 or ISO 11404 standards.
+      </documentation>
+		</annotation>
+		<union memberTypes="duration decimal"/>
+	</simpleType>
+	<!-- ========================================================= -->
+</schema>
+

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsContents.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsContents.xsd
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsContents.xsd 2007-06-06</appinfo>
+		<documentation>This XML Schema Document encodes the Contents section of a GetCapabilities operation response used by the OGC Web Coverage Service (WCS). 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc, All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+       includes and imports
+	============================================================== -->
+	<include schemaLocation="wcsCommon.xsd"/>
+	<import namespace="http://www.opengis.net/ows/1.1" schemaLocation="../../ows/1.1.0/owsAll.xsd"/>
+	<!-- ==============================================================
+       elements and types
+	============================================================== -->
+	<element name="Contents">
+		<annotation>
+			<documentation>Contents section of WCS service metadata (or Capabilities) XML document. For the WCS, these contents are brief metadata about the coverages available from this server, or a reference to another source from which this metadata is available. </documentation>
+		</annotation>
+		<complexType>
+			<sequence>
+				<element ref="wcs:CoverageSummary" minOccurs="0" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of brief metadata describing top-level coverages available from this WCS server. This list shall be included unless one or more OtherSources are referenced and all this metadata is available from those sources. </documentation>
+					</annotation>
+				</element>
+				<element name="SupportedCRS" type="anyURI" minOccurs="0" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of references to coordinate reference systems in which GetCoverage operation requests and responses may be expressed. This list of SupportedCRSs shall be the union of all of the supported CRSs in all of the nested CoverageSummaries. Servers should include this list since it reduces the work clients need to do to determine that they can interoperate with the server. There may be a dependency of SupportedCRS on SupportedFormat, as described in Subclause 10.3.5. </documentation>
+					</annotation>
+				</element>
+				<element name="SupportedFormat" type="ows:MimeType" minOccurs="0" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of identifiers of formats in which GetCoverage operation response may be encoded. This list of SupportedFormats shall be the union of all of the supported formats in all of the nested CoverageSummaries. Servers should include this list since it reduces the work clients need to do to determine that they can interoperate with the server. There may be a dependency of SupportedCRS on SupportedFormat, as described in clause 10.3.5. </documentation>
+					</annotation>
+				</element>
+				<element name="OtherSource" type="ows:OnlineResourceType" minOccurs="0" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of references to other sources of coverage metadata. This list shall be included unless one or more CoverageSummaries are included. </documentation>
+					</annotation>
+				</element>
+			</sequence>
+		</complexType>
+	</element>
+	<!-- =========================================================== -->
+	<element name="CoverageSummary" type="wcs:CoverageSummaryType"/>
+	<!-- =========================================================== -->
+	<complexType name="CoverageSummaryType">
+		<annotation>
+			<documentation>Brief metadata describing one or more coverages available from this WCS server. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="ows:DescriptionType">
+				<sequence>
+					<element ref="ows:Metadata" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Optional unordered list of more metadata elements about this coverage. A list of metadata elements for CoverageSummaries could be specified in a WCS Application Profile. </documentation>
+						</annotation>
+					</element>
+					<element ref="ows:WGS84BoundingBox" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of minimum bounding rectangles surrounding coverage data, using WGS 84 CRS with decimal degrees and longitude before latitude. These bounding boxes shall also apply to lower-level CoverageSummaries under this CoverageSummary, unless other bounding boxes are specified. </documentation>
+						</annotation>
+					</element>
+					<element name="SupportedCRS" type="anyURI" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of references to CRSs in which GetCoverage operation requests and responses may be expressed. These CRSs shall also apply to all lower-level CoverageSummaries under this CoverageSummary, in addition to any other CRSs referenced. </documentation>
+						</annotation>
+					</element>
+					<element name="SupportedFormat" type="ows:MimeType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of identifiers of formats in which GetCoverage operation responses may be encoded. These formats shall also apply to all lower-level CoverageSummaries under this CoverageSummary, in addition to any other formats identified. </documentation>
+						</annotation>
+					</element>
+					<choice>
+						<annotation>
+							<documentation>Each coverage summary shall contain one or more lower-level CoverageSummaries and/or one identifier. </documentation>
+						</annotation>
+						<sequence>
+							<element ref="wcs:CoverageSummary" maxOccurs="unbounded">
+								<annotation>
+									<documentation>Unordered list of lower-level CoverageSummaries under this CoverageSummary. </documentation>
+								</annotation>
+							</element>
+							<element ref="wcs:Identifier" minOccurs="0">
+								<annotation>
+									<documentation>Optional identifier of this coverage. This identifier shall be included only when this coverage can be accessed by the GetCoverage operation, and the CoverageDescription can be accessed by the DescribeCoverage operation. This identifier must be unique for this WCS server. </documentation>
+								</annotation>
+							</element>
+						</sequence>
+						<element ref="wcs:Identifier">
+							<annotation>
+								<documentation>Identifier of this coverage. This identifier must be unique for this WCS server. </documentation>
+							</annotation>
+						</element>
+					</choice>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsCoverages.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsCoverages.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:ows="http://www.opengis.net/ows/1.1" 
+	xmlns="http://www.w3.org/2001/XMLSchema" 
+	elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsCoverages.xsd 2007-07-01</appinfo>
+		<documentation>This XML Schema Document specifies types and elements for groups of coverages, allowing each coverage to include or reference multiple files. 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+		includes and imports
+	============================================================== -->
+	<import namespace="http://www.opengis.net/ows/1.1" schemaLocation="../../ows/1.1.0/owsAll.xsd"/>
+	<!-- ==========================================================
+		Types and elements
+	    ========================================================== -->
+	<element name="Coverages" type="wcs:CoveragesType"/>
+	<!-- ========================================================== -->
+	<complexType name="CoveragesType">
+		<annotation>
+			<documentation>Group of coverages that can be used as the response from the WCS GetCoverage operation, allowing each coverage to include or reference multiple files. This Coverages element may also be used for outputs from, or inputs to, other OWS operations. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="wcs:Coverage" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<!-- ========================================================== -->
+	<element name="Coverage" type="ows:ReferenceGroupType" substitutionGroup="ows:ReferenceGroup">
+		<annotation>
+			<documentation>Complete data for one coverage, referencing each coverage file either remotely or locally in the same message. </documentation>
+		</annotation>
+	</element>
+	<!-- ========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+xmlns:gml="http://www.opengis.net/gml" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsDescribeCoverage.xsd 2007-07-08</appinfo>
+		<appinfo>
+			<GMLProfileSchema>http://schemas.opengis.net/wcs/1.1.1/gml4wcs.xsd</GMLProfileSchema>
+		</appinfo>
+		<documentation>This XML Schema Document defines the DescribeCoverage operation request and response XML elements and types, used by the OGC Web Coverage Service (WCS). 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc, All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+		includes and imports	
+	============================================================== -->
+	<include schemaLocation="wcsCommon.xsd"/>
+	<include schemaLocation="wcsGridCRS.xsd"/>
+	<include schemaLocation="wcsInterpolationMethod.xsd"/>
+	<import namespace="http://www.opengis.net/ows/1.1" schemaLocation="../../ows/1.1.0/owsAll.xsd"/>
+	<import namespace="http://www.opengis.net/gml" schemaLocation="../../gml/3.1.1/base/gml.xsd"/>
+	<!-- ==============================================================    
+	   elements and types	
+	============================================================== -->
+	<element name="DescribeCoverage">
+		<annotation>
+			<documentation>Request to a WCS to perform the DescribeCoverage operation. This operation allows a client to retrieve descriptions of one or more coverages. In this XML encoding, no "request" parameter is included, since the element name specifies the specific operation. </documentation>
+		</annotation>
+		<complexType>
+			<complexContent>
+				<extension base="wcs:RequestBaseType">
+					<sequence>
+						<element ref="wcs:Identifier" maxOccurs="unbounded">
+							<annotation>
+								<documentation>Unordered list of identifiers of desired coverages. A client can obtain identifiers by a prior GetCapabilities request, or from a third-party source. </documentation>
+							</annotation>
+						</element>
+					</sequence>
+				</extension>
+			</complexContent>
+		</complexType>
+	</element>
+	<!-- =========================================================== -->
+	<element name="CoverageDescriptions">
+		<annotation>
+			<documentation>Response from a WCS DescribeCoverage operation, containing one or more coverage descriptions. </documentation>
+		</annotation>
+		<complexType>
+			<sequence>
+				<element name="CoverageDescription" type="wcs:CoverageDescriptionType" maxOccurs="unbounded"/>
+			</sequence>
+		</complexType>
+	</element>
+	<!-- =========================================================== -->
+	<complexType name="CoverageDescriptionType">
+		<annotation>
+			<documentation>Full description of one coverage available from a WCS server. This description shall include sufficient information to allow all valid GetCoverage operation requests to be prepared by a WCS client. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="ows:DescriptionType">
+				<sequence>
+					<element ref="wcs:Identifier">
+						<annotation>
+							<documentation>Unambiguous identifier of this coverage, unique for this WCS server. </documentation>
+						</annotation>
+					</element>
+					<element ref="ows:Metadata" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Optional unordered list of more metadata elements about this coverage. A list of metadata elements for CoverageDescriptions could be specified in a WCS Application Profile. </documentation>
+						</annotation>
+					</element>
+					<element name="Domain" type="wcs:CoverageDomainType"/>
+					<element name="Range" type="wcs:RangeType"/>
+					<element name="SupportedCRS" type="anyURI" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of references to all the coordinate reference systems in which GetCoverage operation requests and responses can be encoded for this coverage. </documentation>
+						</annotation>
+					</element>
+					<element name="SupportedFormat" type="ows:MimeType" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of identifiers of all the formats in which GetCoverage operation responses can be encoded for this coverage. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- =============================================================	
+		Domain types and elements	
+	============================================================== -->
+	<complexType name="CoverageDomainType">
+		<annotation>
+			<documentation>Definition of the spatial-temporal domain of a coverage. The Domain shall include a SpatialDomain (describing the spatial locations for which coverages can be requested), and should included a TemporalDomain (describing the time instants or intervals for which coverages can be requested). </documentation>
+		</annotation>
+		<sequence>
+			<element name="SpatialDomain" type="wcs:SpatialDomainType"/>
+			<element ref="wcs:TemporalDomain" minOccurs="0">
+				<annotation>
+					<documentation>Although optional, the TemporalDomain should be included whenever a value is known or a useful estimate is available. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="SpatialDomainType">
+		<annotation>
+			<documentation>Definition of the spatial domain of a coverage. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="ows:BoundingBox" maxOccurs="unbounded">
+				<annotation>
+					<documentation>The first bounding box shall exactly specify the spatial domain of the offered coverage in the CRS of that offered coverage, thus specifying the available grid row and column indices. For a georectified coverage (that has a GridCRS), this bounding box shall specify the spatial domain in that GridCRS. For an image that is not georectified, this bounding box shall specify the spatial domain in the ImageCRS of that image, whether or not that image is georeferenced. 
+					Additional bounding boxes, if any, shall specify the spatial domain in other CRSs. One bounding box could simply duplicate the information in the ows:WGS84BoundingBox; but the intent is to describe the spatial domain in more detail (e.g., in several different CRSs, or several rectangular areas instead of one overall bounding box). Multiple bounding boxes with the same CRS shall be interpreted as an unordered list of bounding boxes whose union covers spatial domain of this coverage. Notice that WCS use of this BoundingBox is further specified in specification Subclause 7.5. </documentation>
+				</annotation>
+			</element>
+			<element ref="wcs:GridCRS" minOccurs="0">
+				<annotation>
+					<documentation>Definition of GridCRS of the offered coverage. This GridCRS shall be included when this coverage is georectified and is thus stored in a GridCRS. This GridCRS applies to this offered coverage, and specifies its spatial resolution. The definition is included to inform clients of this GridCRS, for possible use in a GetCoverage operation request. </documentation>
+				</annotation>
+			</element>
+			<element name="Transformation" type="gml:AbstractCoordinateOperationType" minOccurs="0">
+				<annotation>
+					<documentation>Georeferencing coordinate transformation for unrectified coverage, which should be included when available for a coverage that is georeferenced but not georectified. When included, this Transformation will specify the variable spatial resolution of this non-georectified image. To support use cases 4, 5, 9, and/or 10 specified in Annex H, a WCS server needs to use a georeferencing coordinate transformation for a georeferenced but not georectified coverage. That georeferencing transformation can be specified as a Transformation, or a ConcatenatedOperation that includes at least one Transformation. However, a WCS server may not support those use cases, not use a georeferencing transformation specified in that manner, or not make that transformation available to clients. </documentation>
+				</annotation>
+			</element>
+			<element name="ImageCRS" type="wcs:ImageCRSRefType" minOccurs="0">
+				<annotation>
+					<documentation>Association to ImageCRS of the offered coverage. This ImageCRS shall be included when this coverage is an image. This imageCRS applies to this offered coverage, but does not (normally) specify its spatial resolution. The ImageCRS for an image coverage is referenced to inform clients of the ImageCRS, for possible use in a GetCoverage operation request. The definition of this ImageCRS shall be included unless the association reference URI completely specifies that ImageCRS (such as by using the URL of the definition or using a suitable URN). </documentation>
+				</annotation>
+			</element>
+			<element ref="gml:Polygon" minOccurs="0" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Unordered list of polygons which more accurately describe the coverage spatial domain in various CRSs. Polygons are particularly useful for areas that are poorly approximated by a BoundingBox (such as satellite image swaths, island groups, other non-convex areas). </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- =========================================================== -->
+	<complexType name="ImageCRSRefType">
+		<annotation>
+			<documentation>Association to an image coordinate reference system, either referencing or containing the definition of that reference system. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:ImageCRS" minOccurs="0"/>
+		</sequence>
+		<attributeGroup ref="gml:AssociationAttributeGroup"/>
+	</complexType>
+	<!-- ========================================================== -->
+	<element name="TemporalDomain" type="wcs:TimeSequenceType">
+		<annotation>
+			<documentation>Definition of the temporal domain of a coverage, the times for which valid data are available. The times should to be ordered from the oldest to the newest. </documentation>
+		</annotation>
+	</element>
+	<!-- =============================================================
+		 Range types and elements
+ 		============================================================== -->
+	<complexType name="RangeType">
+		<annotation>
+			<documentation>Defines the fields (categories, measures, or values) in the range records available for each location in the coverage domain. Each such field may be a scalar (numeric or text) value, such as population density, or a vector (compound or tensor) of many similar values, such as incomes by race, or radiances by wavelength. Each range field is typically an observable whose meaning and reference system are referenced by URIs. </documentation>
+		</annotation>
+		<sequence>
+			<element name="Field" type="wcs:FieldType" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Unordered list of the Fields in the Range of a coverage. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- ========================================================== -->
+	<complexType name="FieldType">
+		<annotation>
+			<documentation>Description of an individual field in a coverage range record. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="ows:DescriptionType">
+				<sequence>
+					<element ref="wcs:Identifier">
+						<annotation>
+							<documentation>Identifier of this Field. These field identifiers shall be unique in one CoverageDescription. </documentation>
+						</annotation>
+					</element>
+					<element name="Definition" type="ows:UnNamedDomainType">
+						<annotation>
+							<documentation>Further definition of this field, including meaning, units, etc. In this Definition, the AllowedValues should be used to encode the extent of possible values for this field, excluding the Null Value. If the range is not known, AnyValue should be used. </documentation>
+						</annotation>
+					</element>
+					<element name="NullValue" type="ows:CodeType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of the values used when valid Field values are not available for whatever reason. The coverage encoding itself may specify a fixed value for null (e.g. “–99999” or “N/A”), but often the choice is up to the provider and must be communicated to the client outside the coverage itself. Each null value shall be encoded as a string. The optional codeSpace attribute can reference a definition of the reason why this value is null. </documentation>
+						</annotation>
+					</element>
+					<element ref="wcs:InterpolationMethods">
+						<annotation>
+							<documentation>Spatial interpolation method(s) that server can apply to this field. One of these interpolation methods shall be used when a GetCoverage operation request requires resampling. When the only interpolation method listed is ‘none’, clients may only retrieve coverages from this coverage in its native CRS at its native resolution. </documentation>
+						</annotation>
+					</element>
+					<element name="Axis" type="wcs:AxisType" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Unordered list of the axes in a vector field for which there are Field values. This list shall be included when this Field has a vector of values. Notice that the axes can be listed here in any order; however, the axis order listed here shall be used in the KVP encoding of a GetCoverage operation request (TBR). </documentation>
+						</annotation>
+					</element>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- ========================================================== -->
+	<complexType name="AxisType">
+		<annotation>
+			<documentation>Definition of one axis in a field for which there are a vector of values. </documentation>
+			<documentation>This type is largely a subset of the ows:DomainType as needed for a range field axis. </documentation>
+		</annotation>
+		<complexContent>
+			<extension base="ows:DescriptionType">
+				<sequence>
+					<element ref="wcs:AvailableKeys"/>
+					<element ref="ows:Meaning" minOccurs="0">
+						<annotation>
+							<documentation>Meaning metadata, which should be referenced for this axis. </documentation>
+						</annotation>
+					</element>
+					<element ref="ows:DataType" minOccurs="0">
+						<annotation>
+							<documentation>Data type metadata, which may be referenced for this axis. </documentation>
+						</annotation>
+					</element>
+					<group ref="ows:ValuesUnit" minOccurs="0">
+						<annotation>
+							<documentation>Unit of measure, which should be included when this axis has units or a more complete reference system. </documentation>
+						</annotation>
+					</group>
+					<element ref="ows:Metadata" minOccurs="0" maxOccurs="unbounded">
+						<annotation>
+							<documentation>Optional unordered list of other metadata elements about this axis. A list of required and optional other metadata elements for this quantity can be specified in a WCS Application Profile. </documentation>
+						</annotation>
+					</element>
+				</sequence>
+				<attribute name="identifier" type="wcs:IdentifierType" use="required">
+					<annotation>
+						<documentation>Name or identifier of this axis. </documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</complexContent>
+	</complexType>
+	<!-- ========================================================== -->
+	<element name="AvailableKeys">
+		<annotation>
+			<documentation>List of all the available (valid) key values for this axis. For numeric keys, signed values should be ordered from negative infinity to positive infinity. </documentation>
+		</annotation>
+		<complexType>
+			<sequence>
+				<element name="Key" type="wcs:IdentifierType" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Valid key value for this axis. There will normally be more than one key value for an axis, but one is allowed for special circumstances. </documentation>
+					</annotation>
+				</element>
+			</sequence>
+		</complexType>
+	</element>
+	<!-- ========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsGetCapabilities.xsd 2007-06-05</appinfo>
+		<documentation>This XML Schema Document encodes the GetCapabilities operation request and response used by the OGC Web Coverage Service (WCS). 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc, All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+       includes and imports
+	============================================================== -->
+	<include schemaLocation="wcsContents.xsd"/>
+	<import namespace="http://www.opengis.net/ows/1.1" schemaLocation="../../ows/1.1.0/owsAll.xsd"/>
+	<!-- ==============================================================
+       elements and types
+	============================================================== -->
+	<element name="GetCapabilities">
+		<annotation>
+			<documentation>Request to a WCS server to perform the GetCapabilities operation. This operation allows a client to retrieve a Capabilities XML document providing metadata for the specific WCS server. In this XML encoding, no "request" parameter is included, since the element name specifies the specific operation. </documentation>
+		</annotation>
+		<complexType>
+			<complexContent>
+				<extension base="ows:GetCapabilitiesType">
+					<sequence/>
+					<attribute name="service" type="ows:ServiceType" use="required" fixed="WCS"/>
+				</extension>
+			</complexContent>
+		</complexType>
+	</element>
+	<!-- =========================================================== -->
+	<element name="Capabilities">
+		<annotation>
+			<documentation>XML encoded WCS GetCapabilities operation response. The Capabilities document provides clients with service metadata about a specific service instance, including metadata about the coverages served. If the server does not implement the updateSequence parameter, the server shall always return the Capabilities document, without the updateSequence parameter. When the server implements the updateSequence parameter and the GetCapabilities operation request included the updateSequence parameter with the current value, the server shall return this element with only the "version" and "updateSequence" attributes. Otherwise, all optional sections shall be included or not depending on the actual value of the Contents parameter in the GetCapabilities operation request. </documentation>
+		</annotation>
+		<complexType>
+			<complexContent>
+				<extension base="ows:CapabilitiesBaseType">
+					<sequence>
+						<element ref="wcs:Contents" minOccurs="0"/>
+					</sequence>
+				</extension>
+			</complexContent>
+		</complexType>
+	</element>
+	<!-- =========================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsGetCoverage.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsGetCoverage.xsd
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:ows="http://www.opengis.net/ows/1.1" 
+	xmlns:gml="http://www.opengis.net/gml" 
+	xmlns="http://www.w3.org/2001/XMLSchema" 
+	elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsGetCoverage.xsd 2007-07-07</appinfo>
+		<appinfo>
+			<GMLProfileSchema>http://schemas.opengis.net/wcs/1.1.1/gml4wcs.xsd</GMLProfileSchema>
+		</appinfo>
+		<documentation>This XML Schema Document defines the GetCoverage operation request elements and types, for the OGC Web Coverage Service (WCS). 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================  
+        includes and imports	
+	============================================================== -->
+	<include schemaLocation="wcsCommon.xsd"/>
+	<include schemaLocation="wcsGridCRS.xsd"/>
+	<include schemaLocation="wcsCoverages.xsd"/>
+	<import namespace="http://www.opengis.net/ows/1.1" schemaLocation="../../ows/1.1.0/owsAll.xsd"/>
+	<import namespace="http://www.opengis.net/gml" schemaLocation="../../gml/3.1.1/base/gml.xsd"/>
+	<!-- ==============================================================	
+		elements and types	
+	============================================================== -->
+	<element name="GetCoverage">
+		<annotation>
+			<documentation>Request to a WCS to perform the GetCoverage operation. This operation allows a client to retrieve a subset of one coverage. In this XML encoding, no "request" parameter is included, since the element name specifies the specific operation. </documentation>
+		</annotation>
+		<complexType>
+			<complexContent>
+				<extension base="wcs:RequestBaseType">
+					<sequence>
+						<element ref="ows:Identifier">
+							<annotation>
+								<documentation>Identifier of the coverage that this GetCoverage operation request shall draw from. </documentation>
+							</annotation>
+						</element>
+						<element name="DomainSubset" type="wcs:DomainSubsetType"/>
+						<element name="RangeSubset" type="wcs:RangeSubsetType" minOccurs="0">
+							<annotation>
+								<documentation>Optional selection of a subset of the coverage's range. </documentation>
+							</annotation>
+						</element>
+						<element name="Output" type="wcs:OutputType"/>
+					</sequence>
+				</extension>
+			</complexContent>
+		</complexType>
+	</element>
+	<!-- ======================================================= -->
+	<complexType name="OutputType">
+		<annotation>
+			<documentation>Asks for the GetCoverage response to be expressed in a particular CRS and encoded in a particular format. Can also ask for the response coverage to be stored remotely from the client at a URL, instead of being returned in the operation response. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="wcs:GridCRS" minOccurs="0">
+				<annotation>
+					<documentation>Optional definition of the GridCRS in which the GetCoverage response shall be expressed. When this GridCRS is not included, the output shall be in the ImageCRS or GridCRS of the offered image, as identified in the CoverageDescription.  To request no interpolation, this GridCRS should be omitted. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute name="format" type="ows:MimeType">
+			<annotation>
+				<documentation>Identifier of the format in which GetCoverage response shall be encoded. This identifier value shall be among those listed as SupportedFormats in the DescribeCoverage operation response. </documentation>
+			</annotation>
+		</attribute>
+		<attribute name="store" type="boolean" use="optional" default="false">
+			<annotation>
+				<documentation>Specifies if the output coverage should be stored, remotely from the client at a network URL, instead of being returned with the operation response. This parameter should be included only if this operation parameter is supported by server, as encoded in the OperationsMetadata section of the Capabilities document. </documentation>
+			</annotation>
+		</attribute>
+	</complexType>
+	<!-- ======================================================= -->
+	<!-- Domain subset types and elements -->
+	<!-- ======================================================= -->
+	<complexType name="DomainSubsetType">
+		<annotation>
+			<documentation>Definition of the desired subset of the domain of the coverage. Contains a spatial BoundingBox and optionally a TemporalSubset. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="ows:BoundingBox">
+				<annotation>
+					<documentation>Definition of desired spatial subset of a coverage domain. When the entire spatial extent of this coverage is desired, this BoundingBox can be copied from the Domain part of the Coverage Description. However, the entire spatial extent may be larger than a WCS server can output, in which case the server shall respond with an error message. Notice that WCS use of this BoundingBox is further specified in specification Subclause 7.5. </documentation>
+				</annotation>
+			</element>
+			<element ref="wcs:TemporalSubset" minOccurs="0">
+				<annotation>
+					<documentation>Optional definition of desired temporal subset of a coverage domain. If this data structure is omitted, the entire Temporal domain shall be output. </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- ======================================================= -->
+	<element name="TemporalSubset" type="wcs:TimeSequenceType">
+		<annotation>
+			<documentation>Definition of subset of coverage temporal domain. </documentation>
+		</annotation>
+	</element>
+	<!-- ======================================================= -->
+	<!-- Range subset types and elements -->
+	<!-- ======================================================= -->
+	<complexType name="RangeSubsetType">
+		<annotation>
+			<documentation>Selection of desired subset of the coverage's range fields, (optionally) the interpolation method applied to each field, and (optionally) field subsets. </documentation>
+		</annotation>
+		<sequence>
+			<element name="FieldSubset" maxOccurs="unbounded">
+				<annotation>
+					<documentation>Unordered list of one or more desired subsets of range fields. TBD. </documentation>
+				</annotation>
+				<complexType>
+					<sequence>
+						<element ref="ows:Identifier">
+							<annotation>
+								<documentation>Identifier of this requested Field. This identifier must be unique for this Coverage. </documentation>
+							</annotation>
+						</element>
+						<element name="InterpolationType" type="string" minOccurs="0">
+							<annotation>
+								<documentation>Optional identifier of the spatial interpolation type to be applied to this range field. This interpolation type shall be one that is identified for this Field in the CoverageDescription. When this parameter is omitted, the interpolation method used shall be the default method specified for this Field, if any. </documentation>
+							</annotation>
+						</element>
+						<element ref="wcs:AxisSubset" minOccurs="0" maxOccurs="unbounded">
+							<annotation>
+								<documentation>Unordered list of zero or more axis subsets for this field. TBD. </documentation>
+							</annotation>
+						</element>
+					</sequence>
+				</complexType>
+			</element>
+		</sequence>
+	</complexType>
+	<!-- ======================================================= -->
+	<element name="AxisSubset">
+		<annotation>
+			<documentation>List of selected Keys for this axis, to be used for selecting values in a vector range field. TBD. </documentation>
+		</annotation>
+		<complexType>
+			<sequence>
+				<element ref="wcs:Identifier">
+					<annotation>
+						<documentation>Identifier of this Axis. This identifier must be unique for this Field. </documentation>
+					</annotation>
+				</element>
+				<element name="Key" type="wcs:IdentifierType" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of (at least one) Key, to be used for selecting values in a range vector field. The Keys within this list shall be unique. TBD. </documentation>
+					</annotation>
+				</element>
+			</sequence>
+		</complexType>
+	</element>
+	<!-- ======================================================= -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsGridCRS.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsGridCRS.xsd
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+	xmlns:gml="http://www.opengis.net/gml" 
+	xmlns="http://www.w3.org/2001/XMLSchema" 
+	elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsGridCRS.xsd 2007-07-01</appinfo>
+		<appinfo>
+			<GMLProfileSchema>http://schemas.opengis.net/wcs/1.1.1/gml4wcs.xsd</GMLProfileSchema>
+		</appinfo>
+		<documentation>This XML Schema Document defines a GridCRS element that is much simpler but otherwise similar to a specialization of gml:DerivedCRS. This GridCRS roughly corresponds to the CV_RectifiedGrid class in ISO 19123, without inheritance from CV_Grid. This GridCRS is designed for use by the OGC Web Coverage Service (WCS) and elsewhere. 
+		This XML Schema Document is not a GML Application Schema, although it uses the GML 3.1.1 profile for WCS 1.1.1. 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc. All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ========================================================
+           includes and imports
+	======================================================== -->
+	<import namespace="http://www.opengis.net/gml" schemaLocation="../../gml/3.1.1/base/gml.xsd"/>
+	<!-- ========================================================
+		elements and types
+	======================================================== -->
+	<element name="GridCRS" type="wcs:GridCrsType"/>
+	<!-- =================================================== -->
+	<complexType name="GridCrsType">
+		<annotation>
+			<documentation>Definition of a coordinate reference system (CRS) for a quadrilateral grid that is defined in another CRS, where this grid is defined by its coordinate Conversion from the other CRS. This GridCRS is not a ProjectedCRS. However, like a ProjectedCRS, the coordinate system used is Cartesian. This GridCRS can use any type of baseCRS, including GeographicCRS, ProjectedCRS, ImageCRS, or a different GridCRS. </documentation>
+			<documentation>This GridCRS is a simplification and specialization of a gml:DerivedCRS. All elements and attributes not required to define this GridCRS are optional. </documentation>
+		</annotation>
+		<sequence>
+			<element ref="gml:srsName" minOccurs="0"/>
+			<element ref="wcs:GridBaseCRS"/>
+			<element ref="wcs:GridType" minOccurs="0">
+				<annotation>
+					<documentation>When this GridType reference is omitted, the OperationMethod shall be the most commonly used method in a GridCRS, which is referenced by the default URN "urn:ogc:def:method:WCS:1.1:2dSimpleGrid". </documentation>
+				</annotation>
+			</element>
+			<element ref="wcs:GridOrigin" minOccurs="0">
+				<annotation>
+					<documentation>When this GridOrigin position is omitted, the origin defaults be the most commonly used origin in a GridCRS used in the output part of a GetCapabilities operation request, namely "0 0". </documentation>
+				</annotation>
+			</element>
+			<element ref="wcs:GridOffsets"/>
+			<element ref="wcs:GridCS" minOccurs="0">
+				<annotation>
+					<documentation>When this GridCS reference is omitted, the GridCS defaults to the most commonly used grid coordinate system, which is referenced by the URN "urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS". </documentation>
+				</annotation>
+			</element>
+		</sequence>
+		<attribute ref="gml:id" use="optional"/>
+	</complexType>
+	<!-- =================================================== -->
+	<element name="GridBaseCRS" type="anyURI">
+		<annotation>
+			<documentation>Association to the coordinate reference system (CRS) in which this Grid CRS is specified. A GridCRS can use any type of baseCRS, including GeographicCRS, ProjectedCRS, ImageCRS, or a different GridCRS. </documentation>
+			<documentation>For a GridCRS, this association is limited to a remote definition of the baseCRS (not encoded in-line). </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="GridType" type="anyURI" default="urn:ogc:def:method:WCS:1.1:2dSimpleGrid">
+		<annotation>
+			<documentation>Association to the OperationMethod used to define this Grid CRS. This association defaults to an association to the most commonly used method, which is referenced by the URN "urn:ogc:def:method:WCS:1.1:2dSimpleGrid". </documentation>
+			<documentation>For a GridCRS, this association is limited to a remote definition of a grid definition Method (not encoded in-line) that encodes a variation on the method implied by the CV_RectifiedGrid class in ISO 19123, without the inheritance from CV_Grid. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="GridOrigin" type="gml:doubleList" default="0 0">
+		<annotation>
+			<documentation>Coordinates of the grid origin position in the GridBaseCRS of this GridCRS. This origin defaults be the most commonly used origin in a GridCRS used in the output part of a GetCapabilities operation request, namely "0 0". </documentation>
+			<documentation>This element is adapted from gml:pos. </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+	<element name="GridOffsets" type="gml:doubleList">
+		<annotation>
+			<documentation>Two or more grid position offsets from the grid origin in the GridBaseCRS of this GridCRS. Example: For the grid2dIn2dCRS OperationMethod, this Offsets element shall contain four values, the first two values shall specify the grid offset for the first grid axis in the 2D base CRS, and the second pair of values shall specify the grid offset for the second grid axis. In this case, the middle two values are zero for un-rotated and un-skewed grids. </documentation>
+		</annotation>
+	</element>
+ 	<!-- =================================================== -->
+	<element name="GridCS" type="anyURI" default="urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS">
+		<annotation>
+			<documentation>Association to the (Cartesian) grid coordinate system used by this Grid CRS. In this use of a (Cartesian) grid coordinate system, the grid positions shall be in the centers of the image or other grid coverage values (not between the grid values), as specified in ISO 19123. Also, the grid point indices at the origin shall be 0, 0 (not 1,1), as specified in ISO 19123. This GridCS defaults to the most commonly used grid coordinate system, which is referenced by the URN "urn:ogc:def:cs:OGC:0.0:Grid2dSquareCS". </documentation>
+			<documentation>For a GridCRS, this association is limited to a remote definition of the GridCS (not encoded in-line). </documentation>
+		</annotation>
+	</element>
+	<!-- =================================================== -->
+</schema>

--- a/src/main/resources/xsd/ogc/wcs/1.1.1/wcsInterpolationMethod.xsd
+++ b/src/main/resources/xsd/ogc/wcs/1.1.1/wcsInterpolationMethod.xsd
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://www.opengis.net/wcs/1.1.1" 
+xmlns:wcs="http://www.opengis.net/wcs/1.1.1" 
+xmlns:ows="http://www.opengis.net/ows/1.1" 
+xmlns="http://www.w3.org/2001/XMLSchema" 
+elementFormDefault="qualified" version="1.1.1" xml:lang="en">
+	<annotation>
+		<appinfo>wcsInterpolationMethod.xsd 2007-06-06</appinfo>
+		<documentation>This XML Schema Document defines interpolation method elements and types, used by the OGC Web Coverage Service (WCS). 
+		Copyright (c) 2007 Open Geospatial Consortium, Inc, All Rights Reserved. </documentation>
+	</annotation>
+	<!-- ==============================================================
+ 	includes and imports	
+	============================================================== -->
+	<import namespace="http://www.opengis.net/ows/1.1" schemaLocation="../../ows/1.1.0/owsAll.xsd"/>
+	<!-- ==============================================================    
+	   elements and types	
+	============================================================== -->
+	<element name="InterpolationMethods">
+		<annotation>
+			<documentation>List of the interpolation method(s) that can uses when continuous grid coverage resampling is needed. </documentation>
+		</annotation>
+		<complexType>
+			<sequence>
+				<element name="InterpolationMethod" type="wcs:InterpolationMethodType" maxOccurs="unbounded">
+					<annotation>
+						<documentation>Unordered list of identifiers of spatial interpolation methods. </documentation>
+					</annotation>
+				</element>
+				<element name="Default" type="string" minOccurs="0">
+					<annotation>
+						<documentation>Identifier of interpolation method that will be used if the client does not specify one. Should be included when a default exists and is known. </documentation>
+						<documentation>(Arliss) Can any string be used to identify an interpolation method in a KVP encoded Get Coverage operation request? </documentation>
+					</annotation>
+				</element>
+			</sequence>
+		</complexType>
+	</element>
+	<!-- ========================================================== -->
+	<complexType name="InterpolationMethodType">
+		<annotation>
+			<documentation>Identifier of a spatial interpolation method applicable to continuous grid coverages, plus the optional "null Resistance" parameter. </documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="wcs:InterpolationMethodBaseType">
+				<attribute name="nullResistance" type="string" use="optional">
+					<annotation>
+						<documentation>Identifier of how the server handles null values when spatially interpolating values in this field using this interpolation method. This identifier shall be selected from the referenced dictionary. This parameter shall be omitted when the rule for handling nulls is unknown. </documentation>
+					</annotation>
+				</attribute>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<!-- ========================================================== -->
+	<complexType name="InterpolationMethodBaseType">
+		<annotation>
+			<documentation>Identifier of an interpolation method applicable to continuous grid coverages. The string in this type shall be one interpolation type identifier string, selected from the referenced dictionary. </documentation>
+			<documentation>Adapts gml:CodeWithAuthorityType from GML 3.2 for this WCS purpose, allowing the codeSpace to be omitted but providing a default value for the standard interpolation methods defined in Annex C of ISO 19123: Geographic information - Schema for coverage geometry and functions. </documentation>
+		</annotation>
+		<simpleContent>
+			<restriction base="ows:CodeType">
+				<attribute name="codeSpace" type="anyURI" use="optional" default="http://schemas.opengis.net/wcs/1.1.0/interpolationMethods.xml">
+					<annotation>
+						<documentation>Reference to a dictionary that specifies allowed values for interpolation method identifier strings and nullResistance identifier strings. This reference defaults to the standard interpolation methods dictionary specified in WCS 1.1.0. </documentation>
+					</annotation>
+				</attribute>
+			</restriction>
+		</simpleContent>
+	</complexType>
+	<!-- ========================================================== -->
+</schema>
+

--- a/src/main/scripts/ctl/wcs.xml
+++ b/src/main/scripts/ctl/wcs.xml
@@ -15,6 +15,7 @@
         <ctl:param name="acceptversions">1.1.1</ctl:param>
         <ctlp:XMLValidatingParser>
           <ctlp:schemas>
+            <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
             <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
           </ctlp:schemas>
         </ctlp:XMLValidatingParser>
@@ -66,6 +67,7 @@
         </xsl:choose>
         <ctlp:XMLValidatingParser>
           <ctlp:schemas>
+            <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
             <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
           </ctlp:schemas>
         </ctlp:XMLValidatingParser>
@@ -210,6 +212,7 @@
             <ctl:param name="acceptversions">1.1.1</ctl:param>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -1626,6 +1629,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -1693,6 +1697,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -1760,6 +1765,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -1827,6 +1833,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -1894,6 +1901,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -1961,6 +1969,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2029,6 +2038,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2099,6 +2109,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2233,6 +2244,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2437,6 +2449,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2501,6 +2514,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2570,6 +2584,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2641,6 +2656,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2711,6 +2727,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2848,6 +2865,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -2916,6 +2934,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -3571,6 +3590,7 @@
             <ctl:param name="sections">OperationsMetadata,Contents</ctl:param>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -4251,6 +4271,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -4440,6 +4461,7 @@
             </xsl:if>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -4895,6 +4917,7 @@
             <ctl:param name="sections">OperationsMetadata,Contents</ctl:param>
             <ctlp:XMLValidatingParser>
               <ctlp:schemas>
+                <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsGetCapabilities.xsd</ctlp:schema>
                 <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsGetCapabilities.xsd</ctlp:schema>
               </ctlp:schemas>
             </ctlp:XMLValidatingParser>
@@ -7043,6 +7066,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -7668,6 +7692,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -7823,6 +7848,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -7978,6 +8004,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -8129,6 +8156,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -8285,6 +8313,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -8418,6 +8447,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -8564,6 +8594,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -8720,6 +8751,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -8876,6 +8908,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -9041,6 +9074,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -9198,6 +9232,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -9356,6 +9391,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -9779,6 +9815,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -9940,6 +9977,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -10492,6 +10530,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -10921,6 +10960,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -11088,6 +11128,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -11259,6 +11300,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -12632,6 +12674,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -13174,6 +13217,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>
@@ -13328,6 +13372,7 @@
                   <xsl:otherwise>
                     <ctlp:XMLValidatingParser>
                       <ctlp:schemas>
+                        <ctlp:schema type="resource">xsd/ogc/wcs/1.1.1/wcsDescribeCoverage.xsd</ctlp:schema>
                         <ctlp:schema type="resource">xsd/ogc/wcs/1.1.3/wcsDescribeCoverage.xsd</ctlp:schema>
                       </ctlp:schemas>
                     </ctlp:XMLValidatingParser>


### PR DESCRIPTION
Now, schema versions 1.1.1 and 1.1.3 are supported in schema validation (see #7).