### PR TITLE
Fixed #2 and #4: Arithmetic operator is not defined for arguments of types (xs:string, xs:string) and Using more than one ows:BoundingBox in coverage description breaks GetCoverage tests

### DIFF
--- a/src/main/scripts/ctl/wcs.xml
+++ b/src/main/scripts/ctl/wcs.xml
@@ -7663,7 +7663,7 @@
                       <xsl:value-of select="$identifier1"/>
                     </ctl:param>
                     <ctl:param name="BoundingBox">
-                      <xsl:value-of select="concat($LowerCornerX - $DeltaX, ',', $LowerCornerY - $DeltaY, ',', $UpperCornerX + $DeltaX, ',', $UpperCornerY + $DeltaY,  ',', $BoundingBoxCRS)"/>
+                      <xsl:value-of select="concat(xs:decimal($LowerCornerX) - $DeltaX, ',', xs:decimal($LowerCornerY) - $DeltaY, ',', xs:decimal($UpperCornerX) + $DeltaX, ',', xs:decimal($UpperCornerY) + $DeltaY,  ',', $BoundingBoxCRS)"/>
                     </ctl:param>
                     <ctl:param name="Format">
                       <xsl:value-of select="$SupportedFormat"/>
@@ -7674,9 +7674,9 @@
                       <GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ows11="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd" service="WCS" version="1.1.1"><ows11:Identifier>
                           <xsl:value-of select="$identifier1"/>
                         </ows11:Identifier><DomainSubset><ows11:BoundingBox crs="{$BoundingBoxCRS}"><ows11:LowerCorner>
-                              <xsl:value-of select="concat($LowerCornerX - $DeltaX, ' ', $LowerCornerY - $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($LowerCornerX) - $DeltaX, ' ', xs:decimal($LowerCornerY) - $DeltaY)"/>
                             </ows11:LowerCorner><ows11:UpperCorner>
-                              <xsl:value-of select="concat($UpperCornerX + $DeltaX, ' ', $UpperCornerY + $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($UpperCornerX) + $DeltaX, ' ', xs:decimal($UpperCornerY) + $DeltaY)"/>
                             </ows11:UpperCorner></ows11:BoundingBox></DomainSubset><Output format="{$SupportedFormat}"/></GetCoverage>
                     </ctl:body>
                   </xsl:otherwise>
@@ -7819,7 +7819,7 @@
                       <xsl:value-of select="$identifier1"/>
                     </ctl:param>
                     <ctl:param name="BoundingBox">
-                      <xsl:value-of select="concat($LowerCornerX + $DeltaX, ',', $LowerCornerY + $DeltaY, ',', $UpperCornerX - $DeltaX, ',', $UpperCornerY - $DeltaY,  ',', $BoundingBoxCRS)"/>
+                      <xsl:value-of select="concat(xs:decimal($LowerCornerX) + $DeltaX, ',', xs:decimal($LowerCornerY) + $DeltaY, ',', xs:decimal($UpperCornerX) - $DeltaX, ',', xs:decimal($UpperCornerY) - $DeltaY,  ',', $BoundingBoxCRS)"/>
                     </ctl:param>
                     <ctl:param name="Format">
                       <xsl:value-of select="$SupportedFormat"/>
@@ -7830,9 +7830,9 @@
                       <GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ows11="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd" service="WCS" version="1.1.1"><ows11:Identifier>
                           <xsl:value-of select="$identifier1"/>
                         </ows11:Identifier><DomainSubset><ows11:BoundingBox crs="{$BoundingBoxCRS}"><ows11:LowerCorner>
-                              <xsl:value-of select="concat($LowerCornerX + $DeltaX, ' ', $LowerCornerY + $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($LowerCornerX) + $DeltaX, ' ', xs:decimal($LowerCornerY) + $DeltaY)"/>
                             </ows11:LowerCorner><ows11:UpperCorner>
-                              <xsl:value-of select="concat($UpperCornerX - $DeltaX, ' ', $UpperCornerY - $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($UpperCornerX) - $DeltaX, ' ', xs:decimal($UpperCornerY) - $DeltaY)"/>
                             </ows11:UpperCorner></ows11:BoundingBox></DomainSubset><Output format="{$SupportedFormat}"/></GetCoverage>
                     </ctl:body>
                   </xsl:otherwise>
@@ -7975,7 +7975,7 @@
                       <xsl:value-of select="$identifier1"/>
                     </ctl:param>
                     <ctl:param name="BoundingBox">
-                      <xsl:value-of select="concat($LowerCornerX + $DeltaX, ',', $LowerCornerY + $DeltaY, ',', $UpperCornerX + $DeltaX, ',', $UpperCornerY + $DeltaY,  ',', $BoundingBoxCRS)"/>
+                      <xsl:value-of select="concat(xs:decimal($LowerCornerX) + $DeltaX, ',', xs:decimal($LowerCornerY) + $DeltaY, ',', xs:decimal($UpperCornerX) + $DeltaX, ',', xs:decimal($UpperCornerY) + $DeltaY,  ',', $BoundingBoxCRS)"/>
                     </ctl:param>
                     <ctl:param name="Format">
                       <xsl:value-of select="$SupportedFormat"/>
@@ -7986,9 +7986,9 @@
                       <GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ows11="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd" service="WCS" version="1.1.1"><ows11:Identifier>
                           <xsl:value-of select="$identifier1"/>
                         </ows11:Identifier><DomainSubset><ows11:BoundingBox crs="{$BoundingBoxCRS}"><ows11:LowerCorner>
-                              <xsl:value-of select="concat($LowerCornerX + $DeltaX, ' ', $LowerCornerY + $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($LowerCornerX) + $DeltaX, ' ', xs:decimal($LowerCornerY) + $DeltaY)"/>
                             </ows11:LowerCorner><ows11:UpperCorner>
-                              <xsl:value-of select="concat($UpperCornerX + $DeltaX, ' ', $UpperCornerY + $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($UpperCornerX) + $DeltaX, ' ', xs:decimal($UpperCornerY) + $DeltaY)"/>
                             </ows11:UpperCorner></ows11:BoundingBox></DomainSubset><Output format="{$SupportedFormat}"/></GetCoverage>
                     </ctl:body>
                   </xsl:otherwise>
@@ -8284,7 +8284,7 @@
                       <xsl:value-of select="$identifier1"/>
                     </ctl:param>
                     <ctl:param name="BoundingBox">
-                      <xsl:value-of select="concat($LowerCornerX + $LengthX + $DeltaX, ',', $LowerCornerY + $LengthY + $DeltaY, ',', $UpperCornerX + $LengthX + $DeltaX, ',', $UpperCornerY + $LengthY + $DeltaY,  ',', $BoundingBoxCRS)"/>
+                      <xsl:value-of select="concat(xs:decimal($LowerCornerX) + $LengthX + $DeltaX, ',', xs:decimal($LowerCornerY) + $LengthY + $DeltaY, ',', xs:decimal($UpperCornerX) + $LengthX + $DeltaX, ',', xs:decimal($UpperCornerY) + $LengthY + $DeltaY,  ',', $BoundingBoxCRS)"/>
                     </ctl:param>
                     <ctl:param name="Format">
                       <xsl:value-of select="$SupportedFormat"/>
@@ -8295,9 +8295,9 @@
                       <GetCoverage xmlns="http://www.opengis.net/wcs/1.1.1" xmlns:gml="http://www.opengis.net/gml" xmlns:ows11="http://www.opengis.net/ows/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wcs/1.1.1 http://schemas.opengis.net/wcs/1.1.1/wcsAll.xsd" service="WCS" version="1.1.1"><ows11:Identifier>
                           <xsl:value-of select="$identifier1"/>
                         </ows11:Identifier><DomainSubset><ows11:BoundingBox crs="{$BoundingBoxCRS}"><ows11:LowerCorner>
-                              <xsl:value-of select="concat($LowerCornerX + $LengthX + $DeltaX, ' ', $LowerCornerY + $LengthY + $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($LowerCornerX) + $LengthX + $DeltaX, ' ', xs:decimal($LowerCornerY) + $LengthY + $DeltaY)"/>
                             </ows11:LowerCorner><ows11:UpperCorner>
-                              <xsl:value-of select="concat($UpperCornerX + $LengthX + $DeltaX, ' ', $UpperCornerY + $LengthY + $DeltaY)"/>
+                              <xsl:value-of select="concat(xs:decimal($UpperCornerX) + $LengthX + $DeltaX, ' ', xs:decimal($UpperCornerY) + $LengthY + $DeltaY)"/>
                             </ows11:UpperCorner></ows11:BoundingBox></DomainSubset><Output format="{$SupportedFormat}"/></GetCoverage>
                     </ctl:body>
                   </xsl:otherwise>

--- a/src/main/scripts/ctl/wcs.xml
+++ b/src/main/scripts/ctl/wcs.xml
@@ -7290,8 +7290,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -7418,8 +7418,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -7636,8 +7636,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -7792,8 +7792,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -7948,8 +7948,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -8104,8 +8104,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -8257,8 +8257,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -8397,8 +8397,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -8530,8 +8530,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -8692,8 +8692,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -8849,8 +8849,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9006,8 +9006,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9172,8 +9172,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9331,8 +9331,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9489,8 +9489,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9624,8 +9624,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9759,8 +9759,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -9913,8 +9913,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -10075,8 +10075,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -10209,8 +10209,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -10338,8 +10338,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -10470,8 +10470,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
@@ -10628,8 +10628,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -10761,8 +10761,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -10894,8 +10894,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11058,8 +11058,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11226,8 +11226,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11398,8 +11398,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11536,8 +11536,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11675,8 +11675,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11793,8 +11793,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -11912,8 +11912,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12028,8 +12028,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12147,8 +12147,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12266,8 +12266,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12384,8 +12384,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12501,8 +12501,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12618,8 +12618,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -12772,8 +12772,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -12900,8 +12900,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -13028,8 +13028,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -13159,8 +13159,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -13315,8 +13315,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
@@ -13470,8 +13470,8 @@
             <xsl:variable name="LowerCornerY" select="substring-after($BoundingBoxLowerCorner, ' ')"/>
             <xsl:variable name="UpperCornerX" select="substring-before($BoundingBoxUpperCorner, ' ')"/>
             <xsl:variable name="UpperCornerY" select="substring-after($BoundingBoxUpperCorner, ' ')"/>
-            <xsl:variable name="LengthX" select="$UpperCornerX - $LowerCornerX"/>
-            <xsl:variable name="LengthY" select="$UpperCornerY - $LowerCornerY"/>
+            <xsl:variable name="LengthX" select="xs:decimal($UpperCornerX) - xs:decimal($LowerCornerX)"/>
+            <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>

--- a/src/main/scripts/ctl/wcs.xml
+++ b/src/main/scripts/ctl/wcs.xml
@@ -7167,7 +7167,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -7260,29 +7260,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -7294,7 +7294,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -7388,29 +7388,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -7422,7 +7422,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -7514,7 +7514,7 @@
             <ctl:fail/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -7606,29 +7606,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -7640,7 +7640,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -7762,29 +7762,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -7796,7 +7796,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -7918,29 +7918,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -7952,7 +7952,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -8074,29 +8074,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -8108,7 +8108,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -8227,29 +8227,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -8261,7 +8261,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -8367,29 +8367,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -8401,7 +8401,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -8500,29 +8500,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -8534,7 +8534,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="TimePosition"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='TemporalDomain']/*[local-name()='TimePositionOrInterval']/*[local-name()='TimePosition']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -8662,29 +8662,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -8696,7 +8696,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -8819,29 +8819,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -8853,7 +8853,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -8976,29 +8976,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9010,7 +9010,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="TimePosition"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='TemporalDomain']/*[local-name()='TimePositionOrInterval']/*[local-name()='TimePosition']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -9142,29 +9142,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9176,7 +9176,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="TimePosition"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='TemporalDomain']/*[local-name()='TimePositionOrInterval']/*[local-name()='TimePosition']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -9301,29 +9301,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9335,7 +9335,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="TimePosition"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='TemporalDomain']/*[local-name()='TimePositionOrInterval']/*[local-name()='TimePosition']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -9459,29 +9459,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9493,7 +9493,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="TimePosition"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='TemporalDomain']/*[local-name()='TimePositionOrInterval']/*[local-name()='TimePosition']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -9594,29 +9594,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9628,7 +9628,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="TimePosition"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='TemporalDomain']/*[local-name()='TimePositionOrInterval']/*[local-name()='TimePosition']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -9729,29 +9729,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9763,7 +9763,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -9883,29 +9883,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -9917,7 +9917,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="FieldIdentifier2"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier'][2]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -10045,29 +10045,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10079,7 +10079,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -10179,29 +10179,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10213,7 +10213,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -10308,29 +10308,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10342,7 +10342,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -10440,29 +10440,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10475,7 +10475,7 @@
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="InterpolationMethod"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='InterpolationMethods']/*[local-name()='InterpolationMethod']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -10598,29 +10598,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10632,7 +10632,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="InterpolationMethod"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='InterpolationMethods']/*[local-name()='InterpolationMethod']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -10731,29 +10731,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10765,7 +10765,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="InterpolationMethod"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='InterpolationMethods']/*[local-name()='InterpolationMethod']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -10864,29 +10864,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -10898,7 +10898,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -11028,29 +11028,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11062,7 +11062,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -11196,29 +11196,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11230,7 +11230,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -11368,29 +11368,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11402,7 +11402,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -11506,29 +11506,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11540,7 +11540,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -11645,29 +11645,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11679,7 +11679,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="FieldIdentifier2"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier'][2]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -11763,29 +11763,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11797,7 +11797,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="FieldIdentifier2"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier'][2]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -11882,29 +11882,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -11916,7 +11916,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="InterpolationMethod"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='InterpolationMethods']/*[local-name()='InterpolationMethod']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
@@ -11998,29 +11998,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12032,7 +12032,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisIdentifier2"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='Identifier'][2]"/></xsl:variable>
@@ -12117,29 +12117,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12151,7 +12151,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey1"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -12236,29 +12236,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12270,7 +12270,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -12354,29 +12354,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12388,7 +12388,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -12471,29 +12471,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12505,7 +12505,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="FieldIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Identifier']"/></xsl:variable>
             <xsl:variable name="AxisIdentifier"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/@identifier"/></xsl:variable>
             <xsl:variable name="AxisKey"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Range']/*[local-name()='Field']/*[local-name()='Axis']/*[local-name()='AvailableKeys']/*[local-name()='Key']"/></xsl:variable>
@@ -12588,29 +12588,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12622,7 +12622,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -12742,29 +12742,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12870,29 +12870,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -12998,29 +12998,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -13129,29 +13129,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -13163,7 +13163,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="Storable"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='store parameter']"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
@@ -13285,29 +13285,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -13319,7 +13319,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">
@@ -13440,29 +13440,29 @@
           <xsl:otherwise>
             <xsl:variable name="BoundingBoxCRS">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/@crs"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/@crs"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">urn:ogc:def:crs:OGC:2:84</xsl:when>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">urn:ogc:def:crs:OGC:2:84</xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxLowerCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']//*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]//*[local-name()='LowerCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='LowerCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='LowerCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
             <xsl:variable name="BoundingBoxUpperCorner">
               <xsl:choose>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
-                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']">
-                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox']/*[local-name()='UpperCorner']"/>
+                <xsl:when test="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]">
+                  <xsl:value-of select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='WGS84BoundingBox'][1]/*[local-name()='UpperCorner']"/>
                 </xsl:when>
               </xsl:choose>
             </xsl:variable>
@@ -13474,7 +13474,7 @@
             <xsl:variable name="LengthY" select="xs:decimal($UpperCornerY) - xs:decimal($LowerCornerY)"/>
             <xsl:variable name="DeltaX" select="$LengthX * 0.025"/>
             <xsl:variable name="DeltaY" select="$LengthY * 0.025"/>
-            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat']"/></xsl:variable>
+            <xsl:variable name="SupportedFormat"><xsl:value-of select = "$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='SupportedFormat'][1]"/></xsl:variable>
             <xsl:variable name="GridBaseCRS" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridBaseCRS']"/>
             <xsl:variable name="GridOffsets" select="$describe-min-result/*[local-name()='CoverageDescriptions']/*[local-name()='CoverageDescription']/*[local-name()='Domain']/*[local-name()='SpatialDomain']/*[local-name()='GridCRS']/*[local-name()='GridOffsets']"/>
             <xsl:variable name="get-coverage-result">


### PR DESCRIPTION
Fixed by converting data types.

In addition, multiple BoundingBox and SupportedFormat elements are now supported.